### PR TITLE
Add branches & objects for ND-LAr reco + ND-TMS stub

### DIFF
--- a/duneanaobj/StandardRecord/SRGAr.h
+++ b/duneanaobj/StandardRecord/SRGAr.h
@@ -13,7 +13,7 @@
 namespace caf
 {
   /// ND-GAr reconstruction output
-  class SRGAR
+  class SRGAr
   {
     public:
       // for the moment, these "pseudo-reco" fields are just copied from the old ND_CAFMaker branches.

--- a/duneanaobj/StandardRecord/SRGAr.h
+++ b/duneanaobj/StandardRecord/SRGAr.h
@@ -1,0 +1,33 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRGAr.h
+// \brief   ND-GAr reconstruction output.
+// \author  J. Wolcott <jwolcott@fnal.gov>
+// \date    Jan. 2022
+////////////////////////////////////////////////////////////////////////
+#ifndef DUNEANAOBJ_SRGAR_H
+#define DUNEANAOBJ_SRGAR_H
+
+#include "duneanaobj/StandardRecord/SRTrack.h"
+#include "duneanaobj/StandardRecord/SRShower.h"
+
+namespace caf
+{
+  /// ND-GAr reconstruction output
+  class SRGAR
+  {
+    public:
+      // for the moment, these "pseudo-reco" fields are just copied from the old ND_CAFMaker branches.
+      // once GAr reco is integrated they should be replaced with proper reco
+
+      int nFSP;
+      std::vector<int> pdg;
+      std::vector<float> ptrue;
+      std::vector<float> trkLen;
+      std::vector<float> trkLenPerp;
+      std::vector<float> partEvReco;
+      int gastpc_pi_pl_mult;
+      int gastpc_pi_min_mult;
+  };
+
+}
+#endif //DUNEANAOBJ_SRGAR_H

--- a/duneanaobj/StandardRecord/SRLorentzVector.cxx
+++ b/duneanaobj/StandardRecord/SRLorentzVector.cxx
@@ -5,6 +5,8 @@
 
 #include "duneanaobj/StandardRecord/SRLorentzVector.h"
 
+#include <limits>
+
 namespace caf
 {
   SRLorentzVector::SRLorentzVector() :

--- a/duneanaobj/StandardRecord/SRLorentzVector.cxx
+++ b/duneanaobj/StandardRecord/SRLorentzVector.cxx
@@ -1,0 +1,28 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRLorentzVector.cxx
+// \author  Christopher Backhouse - c.backhouse@ucl.ac.uk
+////////////////////////////////////////////////////////////////////////
+
+#include "duneanaobj/StandardRecord/SRLorentzVector.h"
+
+namespace caf
+{
+  SRLorentzVector::SRLorentzVector() :
+      E (std::numeric_limits<float>::signaling_NaN()),
+      px(std::numeric_limits<float>::signaling_NaN()),
+      py(std::numeric_limits<float>::signaling_NaN()),
+      pz(std::numeric_limits<float>::signaling_NaN())
+  {}
+
+  SRLorentzVector::SRLorentzVector(const TLorentzVector& v)
+      : E(v.E()), px(v.X()), py(v.Y()), pz(v.Z())
+  {
+  }
+
+  SRLorentzVector::operator TLorentzVector() const
+  {
+    return TLorentzVector(px, py, pz, E);
+  }
+
+} // end namespace caf
+////////////////////////////////////////////////////////////////////////

--- a/duneanaobj/StandardRecord/SRLorentzVector.h
+++ b/duneanaobj/StandardRecord/SRLorentzVector.h
@@ -9,9 +9,18 @@
 #ifndef DUNEANAOBJ_SRLORENTZVECTOR_H
 #define DUNEANAOBJ_SRLORENTZVECTOR_H
 
+#if !defined(__GCCXML__) && !defined(__castxml__)
+
+#include <cmath>
+#include <limits>
+
 #include "TMath.h"
 #include "TLorentzVector.h"
 #include "TVector3.h"
+
+#endif
+
+
 
 namespace caf
 {
@@ -21,7 +30,8 @@ namespace caf
       SRLorentzVector();
       virtual ~SRLorentzVector() = default;
 
-#ifndef __GCCXML__
+#if !defined(__GCCXML__) && !defined(__castxml__)
+
       SRLorentzVector(const TLorentzVector& v);
 
       /// Recommend users convert back to TLorentzVector for boosts etc
@@ -33,9 +43,9 @@ namespace caf
       float X() const {return px;}
       float Y() const {return py;}
       float Z() const {return pz;}
-      float Mag() const {return TMath::Sqrt(px*px + py*py + pz*pz);}
+      float Mag() const {return sqrt(px*px + py*py + pz*pz);}
       float Beta() const {return Mag()/E;}
-      float Gamma() const {return 1.0/TMath::Sqrt(1-Beta()*Beta());}
+      float Gamma() const {return 1.0/sqrt(1-Beta()*Beta());}
 
       TVector3 Vect() const {return TVector3(px, py, pz);}
 #endif

--- a/duneanaobj/StandardRecord/SRLorentzVector.h
+++ b/duneanaobj/StandardRecord/SRLorentzVector.h
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////
+/// \file    SRLorentzVector3D.h
+/// \brief   4-vector class with more efficient storage than TLorentzVector.
+///          Ported from NOvA StandardRecord.
+/// \author  C. Backhouse <c.backhouse@ucl.ac.uk>
+/// \date    Sept. 2021
+////////////////////////////////////////////////////////////////////////
+
+#ifndef DUNEANAOBJ_SRLORENTZVECTOR_H
+#define DUNEANAOBJ_SRLORENTZVECTOR_H
+
+#include "TMath.h"
+#include "TLorentzVector.h"
+#include "TVector3.h"
+
+namespace caf
+{
+  class SRLorentzVector
+  {
+    public:
+      SRLorentzVector();
+      virtual ~SRLorentzVector() = default;
+
+#ifndef __GCCXML__
+      SRLorentzVector(const TLorentzVector& v);
+
+      /// Recommend users convert back to TLorentzVector for boosts etc
+      operator TLorentzVector() const;
+
+      // For access as a position vector. For momentum use the member variables
+      // directly.
+      float T() const {return E;}
+      float X() const {return px;}
+      float Y() const {return py;}
+      float Z() const {return pz;}
+      float Mag() const {return TMath::Sqrt(px*px + py*py + pz*pz);}
+      float Beta() const {return Mag()/E;}
+      float Gamma() const {return 1.0/TMath::Sqrt(1-Beta()*Beta());}
+
+      TVector3 Vect() const {return TVector3(px, py, pz);}
+#endif
+
+      float E;
+      float px;
+      float py;
+      float pz;
+  };
+
+}
+#endif //DUNEANAOBJ_SRLORENTZVECTOR_H

--- a/duneanaobj/StandardRecord/SRNDBranch.h
+++ b/duneanaobj/StandardRecord/SRNDBranch.h
@@ -1,0 +1,30 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRNDBranch.h
+// \brief   Branch for ND info.
+// \author  J. Wolcott <jwolcott@fnal.gov>
+// \date    Jan. 2022
+////////////////////////////////////////////////////////////////////////
+
+#ifndef DUNEANAOBJ_SRNDBRANCH_H
+#define DUNEANAOBJ_SRNDBRANCH_H
+
+#include "duneanaobj/StandardRecord/SRGAr.h"
+#include "duneanaobj/StandardRecord/SRNDLAr.h"
+#include "duneanaobj/StandardRecord/SRNDTrackAssn.h"
+#include "duneanaobj/StandardRecord/SRTMS.h"
+
+namespace caf
+{
+  class SRNDBranch
+  {
+    public:
+      SRNDLAr lar;
+      SRGAr   gar;
+      SRTMS   tms;
+
+      std::size_t ntrkmatch = 0;
+      std::vector<caf::SRNDTrackAssn> trkmatch;
+  };
+}
+
+#endif //DUNEANAOBJ_SRNDBRANCH_H

--- a/duneanaobj/StandardRecord/SRNDLAr.h
+++ b/duneanaobj/StandardRecord/SRNDLAr.h
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRNDLAr.h
+// \brief   ND-LAr reconstruction output.
+// \author  J. Wolcott <jwolcott@fnal.gov>
+// \date    Sept. 2021
+////////////////////////////////////////////////////////////////////////
+#ifndef DUNEANAOBJ_SRNDLAR_H
+#define DUNEANAOBJ_SRNDLAR_H
+
+#include "duneanaobj/StandardRecord/SRTrack.h"
+
+namespace caf
+{
+  /// ND-LAr reconstruction output
+  class SRNDLAr
+  {
+    public:
+      std::vector<SRTrack> tracks;
+      std::size_t          ntracks  = 0;
+  };
+
+}
+#endif //DUNEANAOBJ_SRNDLAR_H

--- a/duneanaobj/StandardRecord/SRNDLAr.h
+++ b/duneanaobj/StandardRecord/SRNDLAr.h
@@ -8,6 +8,7 @@
 #define DUNEANAOBJ_SRNDLAR_H
 
 #include "duneanaobj/StandardRecord/SRTrack.h"
+#include "duneanaobj/StandardRecord/SRShower.h"
 
 namespace caf
 {
@@ -17,6 +18,9 @@ namespace caf
     public:
       std::vector<SRTrack> tracks;
       std::size_t          ntracks  = 0;
+
+      std::vector<SRShower> showers;
+      std::size_t           nshowers = 0;
   };
 
 }

--- a/duneanaobj/StandardRecord/SRNDTrackAssn.h
+++ b/duneanaobj/StandardRecord/SRNDTrackAssn.h
@@ -1,12 +1,13 @@
 /// \author  J. Wolcott <jwolcott@fnal.gov> & F. Akbar <fakbar@ur.rochester.edu>
 /// \date    Nov. 2021
 
-#ifndef DUNEANAOBJ_SRNDTRACKMATCH_H
-#define DUNEANAOBJ_SRNDTRACKMATCH_H
+#ifndef DUNEANAOBJ_SRNDTRACKASSN_H
+#define DUNEANAOBJ_SRNDTRACKASSN_H
+
 
 namespace caf
 {
-  class SRNDTrackMatch
+  class SRNDTrackAssn
   {
     public:
       int larid         = -1;        ///< index of ND-LAr track
@@ -16,4 +17,4 @@ namespace caf
   };
 }
 
-#endif //DUNEANAOBJ_SRNDTRACKMATCH_H
+#endif //DUNEANAOBJ_SRNDTRACKASSN_H

--- a/duneanaobj/StandardRecord/SRNDTrackMatch.h
+++ b/duneanaobj/StandardRecord/SRNDTrackMatch.h
@@ -1,0 +1,18 @@
+/// \author  J. Wolcott <jwolcott@fnal.gov> & F. Akbar <fakbar@ur.rochester.edu>
+/// \date    Nov. 2021
+
+#ifndef DUNEANAOBJ_SRNDTRACKMATCH_H
+#define DUNEANAOBJ_SRNDTRACKMATCH_H
+
+
+class SRNDTrackMatch
+{
+  public:
+    int larTrkIdx;
+    int tmsTrkIdx;
+    float xverseDispl;
+    float angularDsipl;
+};
+
+
+#endif //DUNEANAOBJ_SRNDTRACKMATCH_H

--- a/duneanaobj/StandardRecord/SRNDTrackMatch.h
+++ b/duneanaobj/StandardRecord/SRNDTrackMatch.h
@@ -4,15 +4,16 @@
 #ifndef DUNEANAOBJ_SRNDTRACKMATCH_H
 #define DUNEANAOBJ_SRNDTRACKMATCH_H
 
-
-class SRNDTrackMatch
+namespace caf
 {
-  public:
-    int larTrkIdx;
-    int tmsTrkIdx;
-    float xverseDispl;
-    float angularDsipl;
-};
-
+  class SRNDTrackMatch
+  {
+    public:
+      int larTrkIdx;
+      int tmsTrkIdx;
+      float xverseDispl;
+      float angularDsipl;
+  };
+}
 
 #endif //DUNEANAOBJ_SRNDTRACKMATCH_H

--- a/duneanaobj/StandardRecord/SRNDTrackMatch.h
+++ b/duneanaobj/StandardRecord/SRNDTrackMatch.h
@@ -12,7 +12,7 @@ namespace caf
       int larTrkIdx       = -1;
       int tmsTrkIdx       = -1;
       float xverseDispl   = -999.;
-      float angularDsipl  = -999.;
+      float angularDispl  = -999.;
   };
 }
 

--- a/duneanaobj/StandardRecord/SRNDTrackMatch.h
+++ b/duneanaobj/StandardRecord/SRNDTrackMatch.h
@@ -9,10 +9,10 @@ namespace caf
   class SRNDTrackMatch
   {
     public:
-      int larTrkIdx       = -1;
-      int tmsTrkIdx       = -1;
-      float xverseDispl   = -999.;
-      float angularDispl  = -999.;
+      int larid         = -1;        ///< index of ND-LAr track
+      int tmsid         = -1;        ///< index of TMS track
+      float transdispl  = -999.;     ///< perpendicular distance between the two tracks at longitudinal position of matching point
+      float angdispl    = -999.;     ///< angular difference between the two tracks at longitudinal position of matching point
   };
 }
 

--- a/duneanaobj/StandardRecord/SRNDTrackMatch.h
+++ b/duneanaobj/StandardRecord/SRNDTrackMatch.h
@@ -9,10 +9,10 @@ namespace caf
   class SRNDTrackMatch
   {
     public:
-      int larTrkIdx;
-      int tmsTrkIdx;
-      float xverseDispl;
-      float angularDsipl;
+      int larTrkIdx       = -1;
+      int tmsTrkIdx       = -1;
+      float xverseDispl   = -999.;
+      float angularDsipl  = -999.;
   };
 }
 

--- a/duneanaobj/StandardRecord/SRParticleTruth.h
+++ b/duneanaobj/StandardRecord/SRParticleTruth.h
@@ -16,7 +16,7 @@ namespace caf
   class SRParticleTruth
   {
     public:
-      int   trkID     = 0;   ///< GEANT trackId for particle
+      int   trkid     = 0;   ///< GEANT trackId for particle
       int   pdg       = 0;   ///< PDG Code of the best matched truth particle
       int   motherpdg = 0;   ///< PDG Code of the mother of the best matched truth particle
 

--- a/duneanaobj/StandardRecord/SRParticleTruth.h
+++ b/duneanaobj/StandardRecord/SRParticleTruth.h
@@ -1,0 +1,29 @@
+////////////////////////////////////////////////////////////////////////
+/// \file    SRParticleTruth.h
+/// \brief   Truth information for a true particle
+/// \author  J. Wolcott <jwolcott@fnal.gov>
+/// \date    Sept. 2021
+////////////////////////////////////////////////////////////////////////
+
+#ifndef DUNEANAOBJ_SRPARTICLETRUTH_H
+#define DUNEANAOBJ_SRPARTICLETRUTH_H
+
+#include "duneanaobj/StandardRecord/SRLorentzVector.h"
+#include "duneanaobj/StandardRecord/SRVector3D.h"
+
+namespace caf
+{
+  class SRParticleTruth
+  {
+    public:
+      int   trkID     = 0;   ///< GEANT trackId for particle
+      int   pdg       = 0;   ///< PDG Code of the best matched truth particle
+      int   motherpdg = 0;   ///< PDG Code of the mother of the best matched truth particle
+
+      SRLorentzVector p;       ///< True energy 4-vector of the best matched particle
+      SRLorentzVector motherp; ///< True energy 4-vector of the mother particle
+      SRVector3D      start;   ///< Start point of true particle in detector coordinates (cm)
+  };
+}
+
+#endif //DUNEANAOBJ_SRPARTICLETRUTH_H

--- a/duneanaobj/StandardRecord/SRShower.h
+++ b/duneanaobj/StandardRecord/SRShower.h
@@ -1,0 +1,28 @@
+////////////////////////////////////////////////////////////////////////
+/// \file    SRShower.h
+/// \brief   Reconstructed shower object
+/// \author  J. Wolcott <jwolcott@fnal.gov>
+/// \date    Sept. 2021
+////////////////////////////////////////////////////////////////////////
+
+#ifndef DUNEANAOBJ_SRSHOWER_H
+#define DUNEANAOBJ_SRSHOWER_H
+
+#include "duneanaobj/StandardRecord/SRVector3D.h"
+#include "duneanaobj/StandardRecord/SRParticleTruth.h"
+
+namespace caf
+{
+  class SRShower
+  {
+    public:
+      SRVector3D start;      ///< Shower 3D start point
+      SRVector3D direction;  ///< Shower 3D end point
+      float Evis = -999.;    ///< Visible energy in voxels corresponding to this shower
+
+      SRParticleTruth truth; ///< Best-match GEANT truth particle for this track
+  };
+
+}
+
+#endif //DUNEANAOBJ_SRSHOWER_H

--- a/duneanaobj/StandardRecord/SRTMS.h
+++ b/duneanaobj/StandardRecord/SRTMS.h
@@ -1,0 +1,20 @@
+/// \author  J. Wolcott <jwolcott@fnal.gov> & F. Akbar <fakbar@ur.rochester.edu>
+/// \date    Nov. 2021
+
+#ifndef DUNEANAOBJ_SRTMS_H
+#define DUNEANAOBJ_SRTMS_H
+
+#include "SRTrack.h"
+
+namespace caf
+{
+  class SRTMS
+  {
+    public:
+      std::vector<caf::SRTrack> tracks;
+      std::size_t               ntracks  = 0;
+
+  };
+
+}
+#endif //DUNEANAOBJ_SRTMS_H

--- a/duneanaobj/StandardRecord/SRTrack.cxx
+++ b/duneanaobj/StandardRecord/SRTrack.cxx
@@ -9,6 +9,6 @@
 
 std::ostream &operator<<(std::ostream &stream, const caf::SRTrack &tr)
 {
-  stream << "caf::SRTrack with start=" << tr.start << "  end=" << tr.end << "  end_dir=" << tr.end_dir;
+  stream << "caf::SRTrack with start=" << tr.start << "  end=" << tr.end << "  end_dir=" << tr.end_dir << "  visE=" << tr.Evis << std::endl;
   return stream;
 }

--- a/duneanaobj/StandardRecord/SRTrack.cxx
+++ b/duneanaobj/StandardRecord/SRTrack.cxx
@@ -1,0 +1,14 @@
+////////////////////////////////////////////////////////////////////////
+/// \file    SRTrack.cxx
+/// \brief   Reconstructed track object
+/// \author  J. Wolcott <jwolcott@fnal.gov>
+/// \date    Sept. 2021
+////////////////////////////////////////////////////////////////////////
+
+#include "duneanaobj/StandardRecord/SRTrack.h"
+
+std::ostream &operator<<(std::ostream &stream, const caf::SRTrack &tr)
+{
+  stream << "caf::SRTrack with start=" << tr.start << "  end=" << tr.end << "  end_dir=" << tr.end_dir;
+  return stream;
+}

--- a/duneanaobj/StandardRecord/SRTrack.cxx
+++ b/duneanaobj/StandardRecord/SRTrack.cxx
@@ -9,6 +9,6 @@
 
 std::ostream &operator<<(std::ostream &stream, const caf::SRTrack &tr)
 {
-  stream << "caf::SRTrack with start=" << tr.start << "  end=" << tr.end << "  end_dir=" << tr.end_dir << "  visE=" << tr.Evis << std::endl;
+  stream << "caf::SRTrack with start=" << tr.start << "  end=" << tr.end << "   start dir=" << tr.dir << "  end_dir=" << tr.end_dir << "  visE=" << tr.Evis << std::endl;
   return stream;
 }

--- a/duneanaobj/StandardRecord/SRTrack.cxx
+++ b/duneanaobj/StandardRecord/SRTrack.cxx
@@ -9,6 +9,6 @@
 
 std::ostream &operator<<(std::ostream &stream, const caf::SRTrack &tr)
 {
-  stream << "caf::SRTrack with start=" << tr.start << "  end=" << tr.end << "   start dir=" << tr.dir << "  end_dir=" << tr.end_dir << "  visE=" << tr.Evis << std::endl;
+  stream << "caf::SRTrack with start=" << tr.start << "  end=" << tr.end << "   start dir=" << tr.dir << "  end_dir=" << tr.enddir << "  visE=" << tr.Evis << std::endl;
   return stream;
 }

--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -17,7 +17,7 @@ namespace caf
     public:
       SRVector3D start;      ///< Track 3D start point
       SRVector3D end;        ///< Track 3D end point
-      SRVector3D end_dir;    ///< Unit vector representing estimate of track direction *taken from endpoint*
+      SRVector3D enddir;    ///< Unit vector representing estimate of track direction *taken from endpoint*
 
       float Evis  = -999.;   ///< Visible energy in voxels corresponding to this track
 

--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -19,6 +19,8 @@ namespace caf
       SRVector3D end;        ///< Track 3D end point
       SRVector3D end_dir;    ///< Unit vector representing estimate of track direction *taken from endpoint*
 
+      float Evis  = -999.;   ///< Visible energy in voxels corresponding to this track
+
       SRParticleTruth truth; ///< Best-match GEANT truth particle for this track
   };
 

--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -1,0 +1,27 @@
+////////////////////////////////////////////////////////////////////////
+/// \file    SRTrack.h
+/// \brief   Reconstructed track object
+/// \author  J. Wolcott <jwolcott@fnal.gov>
+/// \date    Sept. 2021
+////////////////////////////////////////////////////////////////////////
+#ifndef DUNEANAOBJ_SRTRACK_H
+#define DUNEANAOBJ_SRTRACK_H
+
+#include "duneanaobj/StandardRecord/SRVector3D.h"
+#include "duneanaobj/StandardRecord/SRParticleTruth.h"
+
+namespace caf
+{
+  class SRTrack
+  {
+    public:
+      SRVector3D start;      ///< Track 3D start point
+      SRVector3D end;        ///< Track 3D end point
+      SRVector3D end_dir;    ///< Unit vector representing estimate of track direction *taken from endpoint*
+
+      SRParticleTruth truth; ///< Best-match GEANT truth particle for this track
+  };
+
+}
+
+#endif //DUNEANAOBJ_SRTRACK_H

--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -17,7 +17,8 @@ namespace caf
     public:
       SRVector3D start;      ///< Track 3D start point
       SRVector3D end;        ///< Track 3D end point
-      SRVector3D enddir;    ///< Unit vector representing estimate of track direction *taken from endpoint*
+      SRVector3D dir;        ///< Unit vector representing estimate of track direction *taken from start point*
+      SRVector3D enddir;     ///< Unit vector representing estimate of track direction *taken from endpoint*
 
       float Evis  = -999.;   ///< Visible energy in voxels corresponding to this track
 

--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -24,4 +24,7 @@ namespace caf
 
 }
 
+std::ostream & operator<<(std::ostream & stream, const caf::SRTrack & tr);
+
+
 #endif //DUNEANAOBJ_SRTRACK_H

--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -26,7 +26,8 @@ namespace caf
 
 }
 
+#if !defined(__GCCXML__) && !defined(__castxml__)
 std::ostream & operator<<(std::ostream & stream, const caf::SRTrack & tr);
-
+#endif
 
 #endif //DUNEANAOBJ_SRTRACK_H

--- a/duneanaobj/StandardRecord/SRVector3D.cxx
+++ b/duneanaobj/StandardRecord/SRVector3D.cxx
@@ -5,6 +5,9 @@
 
 #include "duneanaobj/StandardRecord/SRVector3D.h"
 
+#include <cmath>
+#include <limits>
+
 namespace caf
 {
   SRVector3D::SRVector3D() :

--- a/duneanaobj/StandardRecord/SRVector3D.cxx
+++ b/duneanaobj/StandardRecord/SRVector3D.cxx
@@ -34,3 +34,9 @@ namespace caf
   }
 
 }
+
+std::ostream &operator<<(std::ostream &stream, const caf::SRVector3D &vec)
+{
+  stream << "(" << vec.x << "," << vec.y << "," << vec.z << ")";
+  return stream;
+}

--- a/duneanaobj/StandardRecord/SRVector3D.cxx
+++ b/duneanaobj/StandardRecord/SRVector3D.cxx
@@ -1,0 +1,36 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRLorentzVector.cxx
+// \author  Christopher Backhouse - c.backhouse@ucl.ac.uk
+////////////////////////////////////////////////////////////////////////
+
+#include "duneanaobj/StandardRecord/SRVector3D.h"
+
+namespace caf
+{
+  SRVector3D::SRVector3D() :
+      x(std::numeric_limits<float>::signaling_NaN()),
+      y(std::numeric_limits<float>::signaling_NaN()),
+      z(std::numeric_limits<float>::signaling_NaN())
+  {}
+
+  SRVector3D::SRVector3D(float _x, float _y, float _z) :
+      x(_x), y(_y), z(_z)
+  {}
+
+  SRVector3D::SRVector3D(const TVector3& v) :
+      x(v.X()), y(v.Y()), z(v.Z())
+  {}
+
+  void SRVector3D::SetXYZ(float _x, float _y, float _z)
+  {
+    x = _x;
+    y = _y;
+    z = _z;
+  }
+
+  SRVector3D::operator TVector3() const
+  {
+    return TVector3(x, y, z);
+  }
+
+}

--- a/duneanaobj/StandardRecord/SRVector3D.h
+++ b/duneanaobj/StandardRecord/SRVector3D.h
@@ -1,0 +1,60 @@
+////////////////////////////////////////////////////////////////////////
+/// \file    SRVector3D.h
+/// \brief   3-vector class with more efficient storage than TVector3.
+///          Ported from NOvA StandardRecord.
+/// \author  C. Backhouse <c.backhouse@ucl.ac.uk>
+/// \date    Sept. 2021
+////////////////////////////////////////////////////////////////////////
+
+#ifndef DUNEANAOBJ_SRVECTOR3D_H
+#define DUNEANAOBJ_SRVECTOR3D_H
+
+#include "TVector3.h"
+
+namespace caf
+{
+  /// A 3-vector with more efficient storage than TVector3
+  class SRVector3D
+  {
+    public:
+      SRVector3D();
+      SRVector3D(float x, float y, float z);
+      /// Easy conversion from TVector3
+      SRVector3D(const TVector3& v);
+
+      virtual ~SRVector3D() = default;
+
+      void SetXYZ(float x, float y, float z);
+
+      /// Easy conversion back to TVector3
+      operator TVector3() const;
+
+      void SetX(float _x){x = _x;}
+      void SetY(float _y){y = _y;}
+      void SetZ(float _z){z = _z;}
+
+      float X() const {return x;}
+      float Y() const {return y;}
+      float Z() const {return z;}
+
+      // The more common TVector3 operations, mostly for use with TTree::Draw
+      //
+      // NB: you need to specify the initial "rec." when using these
+      float Mag2() const {return x*x+y*y+z*z;}
+      float Mag() const {return sqrt(Mag2());}
+      float Dot(const SRVector3D& v) const {return x*v.x + y*v.y + z*v.z;}
+      SRVector3D Unit() const
+      {
+        const float m = Mag();
+        return SRVector3D(x/m, y/m, z/m);
+      }
+
+      // -----------------------------
+
+      float x;
+      float y;
+      float z;
+  };
+
+}
+#endif //DUNEANAOBJ_SRVECTOR3D_H

--- a/duneanaobj/StandardRecord/SRVector3D.h
+++ b/duneanaobj/StandardRecord/SRVector3D.h
@@ -57,4 +57,8 @@ namespace caf
   };
 
 }
+
+// make writing these out easier
+std::ostream & operator<<(std::ostream & stream, const caf::SRVector3D & vec);
+
 #endif //DUNEANAOBJ_SRVECTOR3D_H

--- a/duneanaobj/StandardRecord/SRVector3D.h
+++ b/duneanaobj/StandardRecord/SRVector3D.h
@@ -9,7 +9,15 @@
 #ifndef DUNEANAOBJ_SRVECTOR3D_H
 #define DUNEANAOBJ_SRVECTOR3D_H
 
+#if !defined(__GCCXML__) && !defined(__castxml__)
+
+#include <cmath>
+#include <iostream>
+
 #include "TVector3.h"
+
+#endif
+
 
 namespace caf
 {
@@ -19,13 +27,17 @@ namespace caf
     public:
       SRVector3D();
       SRVector3D(float x, float y, float z);
+
+#if !defined(__GCCXML__) && !defined(__castxml__)
       /// Easy conversion from TVector3
-      SRVector3D(const TVector3& v);
+      explicit SRVector3D(const TVector3& v);
+#endif
 
       virtual ~SRVector3D() = default;
 
       void SetXYZ(float x, float y, float z);
 
+#if !defined(__GCCXML__) && !defined(__castxml__)
       /// Easy conversion back to TVector3
       operator TVector3() const;
 
@@ -49,6 +61,11 @@ namespace caf
         return SRVector3D(x/m, y/m, z/m);
       }
 
+      // a few more of them...
+      SRVector3D operator+(const SRVector3D & other) const { return SRVector3D(x + other.x, y + other.y, z + other.z); }
+      SRVector3D operator-(const SRVector3D & other) const {return SRVector3D(x - other.x, y - other.y, z - other.z); }
+#endif
+
       // -----------------------------
 
       float x;
@@ -58,7 +75,9 @@ namespace caf
 
 }
 
+#if !defined(__GCCXML__) && !defined(__castxml__)
 // make writing these out easier
 std::ostream & operator<<(std::ostream & stream, const caf::SRVector3D & vec);
+#endif
 
 #endif //DUNEANAOBJ_SRVECTOR3D_H

--- a/duneanaobj/StandardRecord/StandardRecord.cxx
+++ b/duneanaobj/StandardRecord/StandardRecord.cxx
@@ -34,6 +34,7 @@ namespace caf
     NuMomX(kNaN), NuMomY(kNaN), NuMomZ(kNaN),
     LepMomX(kNaN), LepMomY(kNaN), LepMomZ(kNaN), LepE(kNaN),
     LepNuAngle(kNaN),
+    LepEndpoint{kNaN, kNaN, kNaN},
     run(-1), subrun(-1), event(-1),
     isFD(-1), isFHC(-1),
     CVNResultIsAntineutrino(kNaN),
@@ -44,7 +45,7 @@ namespace caf
     CVNResult0Neutrons(kNaN), CVNResult1Neutrons(kNaN), CVNResult2Neutrons(kNaN), CVNResultNNeutrons(kNaN),
     RegCNNNueE(kNaN),
     sigma_Ev_reco(kNaN), sigma_Elep_reco(kNaN), sigma_numu_pid(kNaN), sigma_nue_pid(kNaN),
-    wgt_CrazyFlux(), xsSyst_wgt(),
+    nwgt_CrazyFlux(0), wgt_CrazyFlux(), xsSyst_wgt(),
     total_xsSyst_cv_wgt(kNaN)
   {
   }

--- a/duneanaobj/StandardRecord/StandardRecord.h
+++ b/duneanaobj/StandardRecord/StandardRecord.h
@@ -13,6 +13,7 @@
 
 #include "duneanaobj/StandardRecord/SRNDLAr.h"
 #include "duneanaobj/StandardRecord/SRTMS.h"
+#include "duneanaobj/StandardRecord/SRNDTrackMatch.h"
 #include "duneanaobj/StandardRecord/SRVector3D.h"
 
 /// Common Analysis Files

--- a/duneanaobj/StandardRecord/StandardRecord.h
+++ b/duneanaobj/StandardRecord/StandardRecord.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "duneanaobj/StandardRecord/SRNDLAr.h"
+#include "duneanaobj/StandardRecord/SRVector3D.h"
 
 /// Common Analysis Files
 namespace caf
@@ -184,6 +185,8 @@ namespace caf
     float LepE;
     float LepNuAngle;
 
+    SRVector3D LepEndpoint;
+
     // config
     int run, subrun, event;
     int isFD;
@@ -205,6 +208,7 @@ namespace caf
     float sigma_numu_pid;
     float sigma_nue_pid;
 
+    int nwgt_CrazyFlux;
     std::vector<float> wgt_CrazyFlux;
 
     // First index is systematic ID

--- a/duneanaobj/StandardRecord/StandardRecord.h
+++ b/duneanaobj/StandardRecord/StandardRecord.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "duneanaobj/StandardRecord/SRNDLAr.h"
+#include "duneanaobj/StandardRecord/SRTMS.h"
 #include "duneanaobj/StandardRecord/SRVector3D.h"
 
 /// Common Analysis Files
@@ -58,6 +59,7 @@ namespace caf
     double pileup_energy;
 
     SRNDLAr  ndlar;
+    SRTMS  ndtms;
 
     // gas TPC info
     int nFSP;

--- a/duneanaobj/StandardRecord/StandardRecord.h
+++ b/duneanaobj/StandardRecord/StandardRecord.h
@@ -25,6 +25,11 @@ namespace caf
     StandardRecord();
     ~StandardRecord();
 
+    // Metadata
+    int meta_run;
+    int meta_subrun;
+    double pot;
+
     // Reco info
     float eRec_FromDep; // Unified parameterized reco that can be used at near and far. Should only be used for missing proton energy fake data studies that cannot use the CVN FD Reco
     float Ev_reco; // for ND?
@@ -40,11 +45,24 @@ namespace caf
     int reco_q;
     float Elep_reco;
     float theta_reco;
+    int reco_lepton_pdg;
 
     float RecoLepEnNue;
     float RecoHadEnNue;
     float RecoLepEnNumu;
     float RecoHadEnNumu;
+
+    double pileup_energy;
+
+    // gas TPC info
+    int nFSP;
+    std::vector<int> pdg;
+    std::vector<float> ptrue;
+    std::vector<float> trkLen;
+    std::vector<float> trkLenPerp;
+    std::vector<float> partEvReco;
+    int gastpc_pi_pl_mult;
+    int gastpc_pi_min_mult;
 
     int RecoMethodNue;  // 1 = longest reco track + hadronic, 2 = reco shower with highest charge + hadronic, 3 = all hit charges, -1 = not set
     int RecoMethodNumu; // 1 = longest reco track + hadronic, 2 = reco shower with highest charge + hadronic, 3 = all hit charges, -1 = not set

--- a/duneanaobj/StandardRecord/StandardRecord.h
+++ b/duneanaobj/StandardRecord/StandardRecord.h
@@ -11,9 +11,7 @@
 
 #include <vector>
 
-#include "duneanaobj/StandardRecord/SRNDLAr.h"
-#include "duneanaobj/StandardRecord/SRTMS.h"
-#include "duneanaobj/StandardRecord/SRNDTrackMatch.h"
+#include "duneanaobj/StandardRecord/SRNDBranch.h"
 #include "duneanaobj/StandardRecord/SRVector3D.h"
 
 /// Common Analysis Files
@@ -59,20 +57,7 @@ namespace caf
 
     double pileup_energy;
 
-    SRNDLAr  ndlar;
-    SRTMS  ndtms;
-
-    std::vector<caf::SRNDTrackMatch> ndtrkmatches;
-
-    // gas TPC info
-    int nFSP;
-    std::vector<int> pdg;
-    std::vector<float> ptrue;
-    std::vector<float> trkLen;
-    std::vector<float> trkLenPerp;
-    std::vector<float> partEvReco;
-    int gastpc_pi_pl_mult;
-    int gastpc_pi_min_mult;
+    SRNDBranch nd;
 
     int RecoMethodNue;  // 1 = longest reco track + hadronic, 2 = reco shower with highest charge + hadronic, 3 = all hit charges, -1 = not set
     int RecoMethodNumu; // 1 = longest reco track + hadronic, 2 = reco shower with highest charge + hadronic, 3 = all hit charges, -1 = not set

--- a/duneanaobj/StandardRecord/StandardRecord.h
+++ b/duneanaobj/StandardRecord/StandardRecord.h
@@ -61,6 +61,8 @@ namespace caf
     SRNDLAr  ndlar;
     SRTMS  ndtms;
 
+    std::vector<caf::SRNDTrackMatch> ndtrkmatches;
+
     // gas TPC info
     int nFSP;
     std::vector<int> pdg;

--- a/duneanaobj/StandardRecord/StandardRecord.h
+++ b/duneanaobj/StandardRecord/StandardRecord.h
@@ -11,6 +11,8 @@
 
 #include <vector>
 
+#include "duneanaobj/StandardRecord/SRNDLAr.h"
+
 /// Common Analysis Files
 namespace caf
 {
@@ -53,6 +55,8 @@ namespace caf
     float RecoHadEnNumu;
 
     double pileup_energy;
+
+    SRNDLAr  ndlar;
 
     // gas TPC info
     int nFSP;

--- a/duneanaobj/StandardRecord/classes.h
+++ b/duneanaobj/StandardRecord/classes.h
@@ -1,2 +1,4 @@
+#include <vector>
+
 #include "duneanaobj/StandardRecord/StandardRecord.h"
 #include "duneanaobj/StandardRecord/SRGlobal.h"

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -1,5 +1,9 @@
 <lcgdict>
-  <class name="caf::StandardRecord" ClassVersion="12" >
+  <class name="caf::StandardRecord" ClassVersion="16" >
+   <version ClassVersion="16" checksum="3561138882"/>
+   <version ClassVersion="15" checksum="2381161406"/>
+   <version ClassVersion="14" checksum="186184242"/>
+   <version ClassVersion="13" checksum="3167178798"/>
    <version ClassVersion="12" checksum="1271137447"/>
    <version ClassVersion="11" checksum="151255278"/>
    <version ClassVersion="10" checksum="2482425987"/>
@@ -9,16 +13,37 @@
    <version ClassVersion="10" checksum="3775256529"/>
   </class>
 
-  <class name="caf::SRWeightGlobal"></class>
-  <class name="caf::SRSystParamHeader"></class>
+  <class name="caf::SRWeightGlobal" ClassVersion="10">
+   <version ClassVersion="10" checksum="1612203321"/>
+  </class>
+  <class name="caf::SRSystParamHeader" ClassVersion="10">
+   <version ClassVersion="10" checksum="621537544"/>
+  </class>
 
-  <class name="caf::SRNDLAr"></class>
+  <class name="caf::SRNDLAr" ClassVersion="10">
+   <version ClassVersion="10" checksum="3845592869"/>
+  </class>
 
-  <class name="caf::SRTrack"></class>
-  <class name="std::vector<caf::SRTrack>"></class>
+  <class name="caf::SRTrack" ClassVersion="10">
+   <version ClassVersion="10" checksum="3745325895"/>
+  </class>
+  <class name="std::vector<caf::SRTrack>">
+  </class>
 
-  <class name="caf::SRShower"></class>
-  <class name="std::vector<caf::SRShower>"></class>
+  <class name="caf::SRShower" ClassVersion="10">
+   <version ClassVersion="10" checksum="2243636990"/>
+  </class>
+  <class name="std::vector<caf::SRShower>">
+  </class>
 
-  <class name="caf::SRVector3D"></class>
+  <class name="caf::SRLorentzVector" ClassVersion="10">
+   <version ClassVersion="10" checksum="2776633038"/>
+  </class>
+  <class name="caf::SRVector3D" ClassVersion="10">
+   <version ClassVersion="10" checksum="2884901936"/>
+  </class>
+
+  <class name="caf::SRParticleTruth" ClassVersion="10">
+   <version ClassVersion="10" checksum="1145477858"/>
+  </class>
 </lcgdict>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -1,11 +1,6 @@
 <lcgdict>
-  <class name="caf::StandardRecord" ClassVersion="16" >
-   <version ClassVersion="16" checksum="3561138882"/>
-   <version ClassVersion="15" checksum="2381161406"/>
-   <version ClassVersion="14" checksum="186184242"/>
-   <version ClassVersion="13" checksum="3167178798"/>
-   <version ClassVersion="12" checksum="1271137447"/>
-   <version ClassVersion="11" checksum="151255278"/>
+  <class name="caf::StandardRecord" ClassVersion="11" >
+   <version ClassVersion="11" checksum="3597577923"/>
    <version ClassVersion="10" checksum="2482425987"/>
   </class>
 
@@ -20,12 +15,24 @@
    <version ClassVersion="10" checksum="621537544"/>
   </class>
 
+  <class name="caf::SRNDBranch" ClassVersion="10">
+   <version ClassVersion="10" checksum="2431680929"/>
+  </class>
+
   <class name="caf::SRNDLAr" ClassVersion="10">
    <version ClassVersion="10" checksum="3845592869"/>
   </class>
 
+  <class name="caf::SRGAr" ClassVersion="10">
+   <version ClassVersion="10" checksum="2529880392"/>
+  </class>
+
+  <class name="caf::SRTMS" ClassVersion="10">
+   <version ClassVersion="10" checksum="418048849"/>
+  </class>
+
   <class name="caf::SRTrack" ClassVersion="10">
-   <version ClassVersion="10" checksum="3745325895"/>
+   <version ClassVersion="10" checksum="4110567994"/>
   </class>
   <class name="std::vector<caf::SRTrack>">
   </class>
@@ -44,6 +51,6 @@
   </class>
 
   <class name="caf::SRParticleTruth" ClassVersion="10">
-   <version ClassVersion="10" checksum="1145477858"/>
+   <version ClassVersion="10" checksum="3381095522"/>
   </class>
 </lcgdict>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -4,9 +4,21 @@
    <version ClassVersion="11" checksum="151255278"/>
    <version ClassVersion="10" checksum="2482425987"/>
   </class>
+
   <class name="caf::SRGlobal" ClassVersion="10" >
    <version ClassVersion="10" checksum="3775256529"/>
   </class>
+
   <class name="caf::SRWeightGlobal"></class>
   <class name="caf::SRSystParamHeader"></class>
+
+  <class name="caf::SRNDLAr"></class>
+
+  <class name="caf::SRTrack"></class>
+  <class name="std::vector<caf::SRTrack>"></class>
+
+  <class name="caf::SRShower"></class>
+  <class name="std::vector<caf::SRShower>"></class>
+
+  <class name="caf::SRVector3D"></class>
 </lcgdict>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -1,8 +1,12 @@
 <lcgdict>
-  <class name="caf::StandardRecord" ClassVersion="10" >
+  <class name="caf::StandardRecord" ClassVersion="12" >
+   <version ClassVersion="12" checksum="1271137447"/>
+   <version ClassVersion="11" checksum="151255278"/>
    <version ClassVersion="10" checksum="2482425987"/>
   </class>
   <class name="caf::SRGlobal" ClassVersion="10" >
    <version ClassVersion="10" checksum="3775256529"/>
   </class>
+  <class name="caf::SRWeightGlobal"></class>
+  <class name="caf::SRSystParamHeader"></class>
 </lcgdict>

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -30,13 +30,11 @@ bindir  fq_dir       bin
 # With "product  version" table below, we now define dependencies
 # Add the dependent product and version
 
-product             version       optional
+# product             version       optional
 root                v6_22_08b     gv3
 root                v6_16_00      gv2
 root                v6_12_06a     gv1
 
-# list products required ONLY for the build
-# any products here must NOT have qualifiers
 cetbuildtools  v7_17_01 - only_for_build
 
 # We now define allowed qualifiers and the corresponding qualifiers for the dependencies.
@@ -55,6 +53,7 @@ c2:gv2:debug   c2:debug
 c2:gv2:prof    c2:prof
 e15:gv1:prof   e15:prof
 e15:gv1:debug  e15:debug
+end_qualifier_list
 
 # Preserve tabs and formatting in emacs and vi / vim:
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -2,7 +2,7 @@
 
 # The *parent* line must the first non-commented line and defines this product and version
 # The version should be of the form vxx_yy_zz (e.g. v01_02_03)
-parent duneanaobj v01_01_00
+parent duneanaobj v01_01_01
 defaultqual e20:gv3
 
 # These optional lines define the installed directories where headers,

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -2,7 +2,7 @@
 
 # The *parent* line must the first non-commented line and defines this product and version
 # The version should be of the form vxx_yy_zz (e.g. v01_02_03)
-parent duneanaobj v01_00_00
+parent duneanaobj v01_01_00
 defaultqual e20:gv3
 
 # These optional lines define the installed directories where headers,
@@ -26,9 +26,6 @@ defaultqual e20:gv3
 incdir  product_dir  include
 libdir  fq_dir       lib
 bindir  fq_dir       bin
-gdmldir product_dir
-fcldir  product_dir
-fwdir   product_dir scripts
 
 # With "product  version" table below, we now define dependencies
 # Add the dependent product and version
@@ -36,6 +33,7 @@ fwdir   product_dir scripts
 product             version       optional
 root                v6_22_08b     gv3
 root                v6_16_00      gv2
+root                v6_12_06a     gv1
 
 # list products required ONLY for the build
 # any products here must NOT have qualifiers
@@ -54,7 +52,9 @@ c7:gv3:prof    c7:p383b:prof
 e17:gv2:debug  e17:debug  
 e17:gv2:prof   e17:prof   
 c2:gv2:debug   c2:debug  
-c2:gv2:prof    c2:prof   
+c2:gv2:prof    c2:prof
+e15:gv1:prof   e15:prof
+e15:gv1:debug  e15:debug
 
 # Preserve tabs and formatting in emacs and vi / vim:
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -40,6 +40,12 @@ cetbuildtools  v7_17_01 - only_for_build
 # We now define allowed qualifiers and the corresponding qualifiers for the dependencies.
 # Make the table by adding columns before "notes".
 
+# PLEASE NOTE: the `gv1` qualifier versions exist only as a compatability hack
+# so that `duneanaobj` can be built against a software stack that works with
+# current versions of ND_CAFMaker.
+# Once ND_CAFMaker has been upgraded to work with GENIE v3 and e20,
+# the `e15:gv1` lines below should be removed.
+
 qualifier      root              notes
 e20:gv3:debug  e20:p383b:debug  
 e20:gv3:prof   e20:p383b:prof   

--- a/ups/setup_deps
+++ b/ups/setup_deps
@@ -39,7 +39,7 @@ test -z "$db" && tnotnull BASH_SOURCE && set_ me=`dirname $BASH_SOURCE` && set_ 
 
 # history is applicable only for interactive t/csh
 test -z "$db" -a "$ss" = csh && test $?history = 0 && set history=5  # make sure history 1 works
-test -z "$db" -a "$ss" = csh && set me=`history 1|sed 's/^[     0-9:]*//'` && test -n "$me" && set me=`dirname $me[2]` \
+test -z "$db" -a "$ss" = csh && set me=`history 1|sed 's/^[ 	0-9:]*//'` && test -n "$me" && set me=`dirname $me[2]` \
     && set db=`sh -c "cd $me >/dev/null 2>&1 && pwd"` && vecho_ 'setting db via interactive history'
 #echo This script lives in $db
 
@@ -59,21 +59,26 @@ set_ msg5='ERROR: setup of required products has failed'
 
 echo ----------- check this block for errors -----------------------
 set_ setup_fail="false"
-set_ cetb=` grep only_for_build $CETPKG_SOURCE/ups/product_deps | grep cetbuildtools | awk '{ print $2 }' `
-set_ cetv=` grep only_for_build $CETPKG_SOURCE/ups/product_deps | grep cetbuildtools | awk '{ print $3 }' `
+set_ exit_now="false"
+set_ cetb=` grep -e '^[ \t]*cetbuildtools' $CETPKG_SOURCE/ups/product_deps | grep  only_for_build| awk '{ print $1 }' `
+set_ cetv=` grep -e '^[ \t]*cetbuildtools' $CETPKG_SOURCE/ups/product_deps | grep  only_for_build| awk '{ print $2 }' `
 #echo Found $cetb $cetv
 setup -B $cetb $cetv
 test "$?" = 0 || set_ setup_fail="true"
-setenv UPS_OVERRIDE -B
 # now get the rest of the products
 set_ cmd="$CETBUILDTOOLS_DIR/bin/set_dev_products $CETPKG_SOURCE $CETPKG_BUILD $*"
 #echo Ready to run $cmd
 source `$cmd`
+test "$?" = 0 || set_ setup_fail="true"
 #echo "$cmd returned $setup_fail"
 test "$setup_fail" = "true" && echo "$msg5"
-test "$setup_fail" = "true" && return 1
-test -e "diag_report" && cat diag_report
+test "$setup_fail" = "true" && set_ exit_now="true"
+test -e "$CETPKG_BUILD/diag_report" && cat $CETPKG_BUILD/diag_report
 echo ----------------------------------------------------------------
+
+test "${exit_now}" = "true" && test "$ss" = csh && unalias tnotnull nullout set_ vecho_ return
+test "${exit_now}" = "true" && unset ss db me thisdir msg1 msg2 msg3 msg4 msg5 setup_fail set_ setenv unsetenv_ tnotnull nullout vecho_
+test "${exit_now}" = "true" && return 1
 
 # final sanity check and report
 source $CETBUILDTOOLS_DIR/bin/set_dep_check_report
@@ -82,4 +87,3 @@ source $CETBUILDTOOLS_DIR/bin/set_dep_check_report
 test "$ss" = csh && unalias tnotnull nullout set_ vecho_ return
 unset ss db me thisdir msg1 msg2 msg3 msg4 msg5 setup_fail
 unset set_ setenv unsetenv_ tnotnull nullout vecho_
-

--- a/ups/setup_for_development
+++ b/ups/setup_for_development
@@ -39,7 +39,7 @@ test -z "$db" && tnotnull BASH_SOURCE && set_ me=`dirname $BASH_SOURCE` && set_ 
 
 # history is applicable only for interactive t/csh
 test -z "$db" -a "$ss" = csh && test $?history = 0 && set history=5  # make sure history 1 works
-test -z "$db" -a "$ss" = csh && set me=`history 1|sed 's/^[     0-9:]*//'` && test -n "$me" && set me=`dirname $me[2]` \
+test -z "$db" -a "$ss" = csh && set me=`history 1|sed 's/^[ 	0-9:]*//'` && test -n "$me" && set me=`dirname $me[2]` \
     && set db=`sh -c "cd $me >/dev/null 2>&1 && pwd"` && vecho_ 'setting db via interactive history'
 #echo This script lives in $db
 
@@ -57,26 +57,33 @@ set_ msg5='ERROR: setup of required products has failed'
 
 echo ----------- check this block for errors -----------------------
 set_ setup_fail="false"
-set_ cetb=` grep only_for_build $CETPKG_SOURCE/ups/product_deps | grep cetbuildtools | awk '{ print $2 }' `
-set_ cetv=` grep only_for_build $CETPKG_SOURCE/ups/product_deps | grep cetbuildtools | awk '{ print $3 }' `
+set_ exit_now="false"
+set_ cetb=` grep -e '^[ \t]*cetbuildtools' $CETPKG_SOURCE/ups/product_deps | grep  only_for_build| awk '{ print $1 }' `
+set_ cetv=` grep -e '^[ \t]*cetbuildtools' $CETPKG_SOURCE/ups/product_deps | grep  only_for_build| awk '{ print $2 }' `
 #echo Found $cetb $cetv
 setup -B $cetb $cetv
 test "$?" = 0 || set_ setup_fail="true"
-setenv UPS_OVERRIDE -B
 # now get the rest of the products
 set_ cmd="$CETBUILDTOOLS_DIR/bin/set_dev_products $CETPKG_SOURCE $CETPKG_BUILD $*"
 #echo Ready to run $cmd
 source `$cmd`
+test "$?" = 0 || set_ setup_fail="true"
 #echo "$cmd returned $setup_fail"
 test "$setup_fail" = "true" && echo "$msg5"
-test "$setup_fail" = "true" && return 1
+test "$setup_fail" = "true" && set_ exit_now="true"
 test -e "$CETPKG_BUILD/diag_report" && cat $CETPKG_BUILD/diag_report
 echo ----------------------------------------------------------------
+
+test "${exit_now}" = "true" && test "$ss" = csh && unalias tnotnull nullout set_ vecho_ return
+test "${exit_now}" = "true" && unset ss db me thisdir msg1 msg2 msg3 msg4 msg5 setup_fail set_ setenv unsetenv_ tnotnull nullout vecho_
+test "${exit_now}" = "true" && return 1
 
 # add lib to LD_LIBRARY_PATH
 source $CETBUILDTOOLS_DIR/bin/set_dev_lib
 # add bin to path
 source $CETBUILDTOOLS_DIR/bin/set_dev_bin
+# set FHICL_FILE_PATH
+source $CETBUILDTOOLS_DIR/bin/set_dev_fhicl
 # set FW_SEARCH_PATH
 source $CETBUILDTOOLS_DIR/bin/set_dev_fwsearch
 
@@ -87,4 +94,3 @@ source $CETBUILDTOOLS_DIR/bin/set_dev_check_report
 test "$ss" = csh && unalias tnotnull nullout set_ vecho_ return
 unset ss db me thisdir msg1 msg2 msg3 msg4 msg5 setup_fail
 unset set_ setenv unsetenv_ tnotnull nullout vecho_
-


### PR DESCRIPTION
This PR would introduce fields to contain information for the ND-LAr reco output.  They are nested underneath a new `SRNDLAr` object type, which itself introduces a few extras like `SRTrack` and `SRShower`.  I have also ported the various `float` replacements for ROOT's `Vector3D` and `SRLorentzVector` from NOvA's CAFAna.

This PR would furthermore introduce the stubs for ND-TMS integration, which is impending: an `SRTMS` object (which is currently a skeleton with only a vector of `SRTrack`s in it); and a `SRNDTrackMatch` object (even more of a stub) which will eventually map between ND-LAr and TMS (or ND-GAr) reconstructed tracks.

I have used it to develop a proof-of-principle ND-LAr CC numu analysis as described in https://indico.fnal.gov/event/52169/.