### PR TITLE
Expand SRTrack to include track energy, length, and quality quantities

### DIFF
--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -23,10 +23,10 @@ namespace caf
       float Evis  = -999.;   ///< Visible energy in voxels corresponding to this track
 
       // Track characteristics
-      float TrackLength_gcm3 = -999.; ///< Track length in g/cm3
-      float TrackEnergy = -999; ///< Track energy in MeV
-      float TrackLength_cm = -999; ///< Track length in centimeter (actual physical distance)
-      float TrackQuality = -999; ///< Track quality metric (in TMS, equivalent to "hits in track"/"total hits in event"
+      float len_gcm3 = -999.; ///< Track length in g/cm3
+      float E = -999; ///< Track energy in MeV
+      float len_cm = -999; ///< Track length in centimeter (actual physical distance)
+      float qual = -999; ///< Track quality metric (in TMS, equivalent to "hits in track"/"total hits in event"
 
       SRParticleTruth truth; ///< Best-match GEANT truth particle for this track
   };

--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -22,6 +22,12 @@ namespace caf
 
       float Evis  = -999.;   ///< Visible energy in voxels corresponding to this track
 
+      // Track characteristics
+      float TrackLength_gcm3 = -999.; ///< Track length in g/cm3
+      float TrackEnergy = -999; ///< Track energy in MeV
+      float TrackLength_cm = -999; ///< Track length in centimeter (actual physical distance)
+      float TrackQuality = -999; ///< Track quality metric (in TMS, equivalent to "hits in track"/"total hits in event"
+
       SRParticleTruth truth; ///< Best-match GEANT truth particle for this track
   };
 


### PR DESCRIPTION
Minimal commit to include more track information into the standard record track class. Should be relevant for all DUNE ND subdetectors, although this is specifically created with the TMS in mind.