### PR TITLE
Change std::float_t to float

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required (VERSION 3.12...3.18 FATAL_ERROR)
 
 project(duneanaobj LANGUAGES CXX)
-set(${PROJECT_NAME}_CMAKE_PROJECT_VERSION_STRING 02.00.00)
+set(${PROJECT_NAME}_CMAKE_PROJECT_VERSION_STRING 02.00.01)
 
 message(STATUS "\n\n  ==========================   ${PROJECT_NAME}   ==========================")
 

--- a/duneanaobj/StandardRecord/SRNDBranch.h
+++ b/duneanaobj/StandardRecord/SRNDBranch.h
@@ -27,8 +27,8 @@ namespace caf
     
       std::size_t LArID = 0;
       std::size_t TMSID = 0;
-      std::float_t Residual = 0.0;
-      std::float_t cosTheta = 0.0;
+      float Residual = 0.0;
+      float cosTheta = 0.0;
   };
 }
 


### PR DESCRIPTION
SRProxy chokes on std::float_t (perhaps because the right headers aren't included?). Just change to regular float to match the rest of SRProxy.

Bump version number to v02.00.01

Perhaps this is an argument to add the Proxy/ subdir directly in StandardRecord, as it is in nova and sbn, so we don't have to go through a whole release cycle to detect this kind of problem.