### PR TITLE
Feature/sr track expansion

### DIFF
--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -23,7 +23,7 @@ namespace caf
       float Evis  = -999.;   ///< Visible energy in voxels corresponding to this track
 
       // Track characteristics
-      float len_gcm3 = -999.; ///< Track length in g/cm3
+      float len_gcm2 = -999.; ///< Track length in g/cm2
       float E = -999; ///< Track energy in MeV
       float len_cm = -999; ///< Track length in centimeter (actual physical distance)
       float qual = -999; ///< Track quality metric (in TMS, equivalent to "hits in track"/"total hits in event"

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -1,4 +1,10 @@
 <lcgdict>
+  <class name="caf::SRNDTrackAssn" ClassVersion="10">
+   <version ClassVersion="10" checksum="884165698"/>
+  </class>
+  <class name="std::vector<caf::SRNDTrackAssn>">
+  </class>
+
   <class name="caf::StandardRecord" ClassVersion="11" >
    <version ClassVersion="11" checksum="3597577923"/>
    <version ClassVersion="10" checksum="2482425987"/>
@@ -15,7 +21,9 @@
    <version ClassVersion="10" checksum="621537544"/>
   </class>
 
-  <class name="caf::SRNDBranch" ClassVersion="10">
+  <class name="caf::SRNDBranch" ClassVersion="12">
+   <version ClassVersion="12" checksum="2431680929"/>
+   <version ClassVersion="11" checksum="1041684133"/>
    <version ClassVersion="10" checksum="2431680929"/>
   </class>
 
@@ -31,7 +39,10 @@
    <version ClassVersion="10" checksum="418048849"/>
   </class>
 
-  <class name="caf::SRTrack" ClassVersion="10">
+  <class name="caf::SRTrack" ClassVersion="13">
+   <version ClassVersion="13" checksum="1538684939"/>
+   <version ClassVersion="12" checksum="1834229612"/>
+   <version ClassVersion="11" checksum="1751365267"/>
    <version ClassVersion="10" checksum="4110567994"/>
   </class>
   <class name="std::vector<caf::SRTrack>">


### PR DESCRIPTION
Changes variable name in SRTrack to len_gcm2 (gcm3 was just a typo); will push appropriate commit to ND_CAFMaker too

Change classes_def.xml to include the LArTMS matcher. This missing clause meant ND_CAFMaker didn't write the LArTMS matcher properly to file, which is fixed with this commit.

Merged in master in the branch before merging, which is the remaining commits.