### PR TITLE
Generate Proxy/ and Flat/ files using SRProxy and increment version number to v 02.01.00

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required (VERSION 3.12...3.18 FATAL_ERROR)
 
 project(duneanaobj LANGUAGES CXX)
-set(${PROJECT_NAME}_CMAKE_PROJECT_VERSION_STRING 02.00.01)
+set(${PROJECT_NAME}_CMAKE_PROJECT_VERSION_STRING 02.01.00)
 
 message(STATUS "\n\n  ==========================   ${PROJECT_NAME}   ==========================")
 

--- a/duneanaobj/StandardRecord/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/CMakeLists.txt
@@ -1,3 +1,6 @@
+add_subdirectory(Proxy)
+add_subdirectory(Flat)
+
 # for classes_def.xml!!
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 

--- a/duneanaobj/StandardRecord/Flat/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Flat/CMakeLists.txt
@@ -1,0 +1,16 @@
+FILE(GLOB SR_DEPENDENCIES duneanaobj/StandardRecord/*.h)
+
+add_custom_command(# Rebuild if anything in StandardRecord/ changes
+                   DEPENDS ${SR_DEPENDENCIES}
+                   OUTPUT FlatRecord.cxx FlatRecord.h FwdDeclare.h
+                   COMMAND gen_srproxy --flat -i duneanaobj/StandardRecord/StandardRecord.h -o FlatRecord --target caf::StandardRecord --include-path $ENV{DUNEANAOBJ_DIR}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Flat/
+  )
+
+include_directories($ENV{SRPROXY_INC})
+
+cet_make_library(LIBRARY_NAME duneanaobj_StandardRecordFlat
+                 SOURCE       FlatRecord.cxx
+                 LIBRARIES    ${ROOT_BASIC_LIB_LIST} ROOT::TreePlayer
+                 )
+
+install_headers(EXTRAS $ENV{MRB_BUILDDIR}/duneanaobj/duneanaobj/StandardRecord/Flat/FlatRecord.h $ENV{MRB_BUILDDIR}/duneanaobj/duneanaobj/StandardRecord/Flat/FwdDeclare.h)

--- a/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
@@ -1,0 +1,18 @@
+FILE(GLOB SR_DEPENDENCIES duneanaobj/StandardRecord/*.h)
+
+add_custom_command(# Rebuild if anything in StandardRecord/ changes
+                   DEPENDS ${SR_DEPENDENCIES}
+                   OUTPUT SRProxy.cxx SRProxy.h FwdDeclare.h
+                   COMMAND gen_srproxy -i duneanaobj/StandardRecord/StandardRecord.h -o SRProxy --target caf::StandardRecord --include-path $ENV{DUNEANAOBJ_DIR}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Proxy/ --epilog-fwd ${CMAKE_CURRENT_SOURCE_DIR}/EpilogFwd.h
+  )
+
+include_directories($ENV{SRPROXY_INC})
+
+# This is a very picky error buried inside template instantiations
+#add_definitions(-Wno-int-in-bool-context)
+
+cet_make_library(LIBRARY_NAME duneanaobj_StandardRecordProxy
+                 SOURCE       SRProxy.cxx Instantiations.cxx
+                 LIBRARIES    ${ROOT_BASIC_LIB_LIST} ROOT::TreePlayer)
+
+install_headers(EXTRAS $ENV{MRB_BUILDDIR}/duneanaobj/duneanaobj/StandardRecord/Proxy/SRProxy.h $ENV{MRB_BUILDDIR}/duneanaobj/duneanaobj/StandardRecord/Proxy/FwdDeclare.h)

--- a/duneanaobj/StandardRecord/Proxy/EpilogFwd.h
+++ b/duneanaobj/StandardRecord/Proxy/EpilogFwd.h
@@ -1,0 +1,3 @@
+
+namespace caf{using SRProxy = caf::Proxy<caf::StandardRecord>;}
+

--- a/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
+++ b/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
@@ -1,0 +1,3 @@
+// This file is the only way BasicTypesProxy.cxx gets compiled at all (the
+// srproxy package doesn't include binaries).
+#include "SRProxy/BasicTypesProxy.cxx"

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -33,16 +33,17 @@ bindir  fq_dir       bin
 product             version       optional
 cetbuildtools  v8_20_00 - only_for_build
 root                v6_22_08d
+srproxy             v00.36
 end_product_list
 
 # We now define allowed qualifiers and the corresponding qualifiers for the dependencies.
 # Make the table by adding columns before "notes".
 
-qualifier      root              notes
-e20:debug  e20:p392:debug
-e20:prof   e20:p392:prof
-c7:debug   c7:p392:debug
-c7:prof    c7:p392:prof
+qualifier      root       srproxy       notes
+e20:debug  e20:p392:debug py3
+e20:prof   e20:p392:prof  py3
+c7:debug   c7:p392:debug  py3
+c7:prof    c7:p392:prof   py3
 end_qualifier_list
 
 # Preserve tabs and formatting in emacs and vi / vim:


### PR DESCRIPTION
Match the design from SBN. This should prevent us making StandardRecord changes that SRProxy will later choke on, and means that we don't have to regenerate the generated files in multiple places downstream.