### PR TITLE
Changes to build with c7, e20 and e24.  Still breaks with c14

### DIFF
--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -157,8 +157,10 @@ namespace caf
   // ----------------------------------------------------------------------
   // now some enums that are used internally so one branch can easily refer to another
 
-  struct TrueParticleID
+  class TrueParticleID
   {
+    public:
+    
       enum PartType { kUnknown, kPrimary, kPrimaryBeforeFSI, kSecondary };
 
       int      ixn  = -1;       ///< Index of SRInteraction in the SRTruthBranch

--- a/duneanaobj/StandardRecord/SRGAr.h
+++ b/duneanaobj/StandardRecord/SRGAr.h
@@ -35,8 +35,10 @@ namespace caf
   };
 
   /// The information needed to uniquely identify a ND-GAr reco object
-  struct SRGArID
+  class SRGArID
   {
+    public:
+    
     int        ixn  = -1;            ///< interaction ID
     int        idx  = -1;            ///< index in container
   };

--- a/duneanaobj/StandardRecord/SRNDLAr.h
+++ b/duneanaobj/StandardRecord/SRNDLAr.h
@@ -24,8 +24,9 @@ namespace caf
   };
 
   /// The information needed to uniquely identify an ND-LAr reco object
-  struct SRNDLArID
+  class SRNDLArID
   {
+  public:
     NDLAR_RECO_STACK reco = kUnknownNDLArReco;  ///< reco stack
     int        ixn  = -1;            ///< interaction ID
     int        idx  = -1;            ///< index in container

--- a/duneanaobj/StandardRecord/SRTMS.h
+++ b/duneanaobj/StandardRecord/SRTMS.h
@@ -17,8 +17,9 @@ namespace caf
   };
 
   /// The information needed to uniquely identify a TMS reco object
-  struct SRTMSID
+  class SRTMSID
   {
+  public:
     int        ixn  = -1;            ///< interaction ID
     int        idx  = -1;            ///< index in container
   };

--- a/duneanaobj/StandardRecord/SRTrueInteraction.h
+++ b/duneanaobj/StandardRecord/SRTrueInteraction.h
@@ -21,6 +21,9 @@
 // namespace std{class string{};}
 // #endif
 
+#ifdef __GNUC__
+#undef _GLIBCXX_HAVE_BUILTIN_IS_CONSTANT_EVALUATED
+#endif
 #include <string>
 
 #include <vector>

--- a/duneanaobj/StandardRecord/SRTrueInteraction.h
+++ b/duneanaobj/StandardRecord/SRTrueInteraction.h
@@ -12,14 +12,17 @@
 #include "duneanaobj/StandardRecord/SRTrueParticle.h"
 #include "duneanaobj/StandardRecord/SRVector3D.h"
 
-// This is pretty ugly. The proper fix is to get a new version of castxml that
-// is built with at least clang v9.
-// See https://github.com/CastXML/CastXML/issues/178
-#ifndef __castxml__
+// // This is pretty ugly. The proper fix is to get a new version of castxml that
+// // is built with at least clang v9.
+// // See https://github.com/CastXML/CastXML/issues/178
+// #ifndef __castxml__
+// #include <string>
+// #else
+// namespace std{class string{};}
+// #endif
+
 #include <string>
-#else
-namespace std{class string{};}
-#endif
+
 #include <vector>
 
 namespace caf

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -42,6 +42,8 @@ end_product_list
 qualifier      root       srproxy       notes
 e20:debug  debug:e20:p3913 py3913
 e20:prof   e20:p3913:prof  py3913
+e26:debug  debug:e26:p3913 py3913
+e26:prof   e26:p3913:prof  py3913
 c7:debug   c7:p3913:debug  py3913
 c7:prof    c7:p3913:prof   py3913
 end_qualifier_list

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -46,6 +46,8 @@ e26:debug  debug:e26:p3913 py3913
 e26:prof   e26:p3913:prof  py3913
 c7:debug   c7:p3913:debug  py3913
 c7:prof    c7:p3913:prof   py3913
+c14:debug  c14:p3913:debug  py3913
+c14:prof   c14:p3913:prof   py3913
 end_qualifier_list
 
 # Preserve tabs and formatting in emacs and vi / vim:


### PR DESCRIPTION


> More info: Trying to get the e20 build of duneanaobj working without the hack. The error is
>
> In file included from /home/trj/dune/app/users/trj/splitter12/srcs/duneanaobj/duneanaobj/StandardRecord/StandardRecord.h:16:
> In file included from /home/trj/dune/app/users/trj/splitter12/srcs/duneanaobj/duneanaobj/StandardRecord/SRTruthBranch.h:11:
> In file included from /home/trj/dune/app/users/trj/splitter12/srcs/duneanaobj/duneanaobj/StandardRecord/SRTrueInteraction.h:25:
> In file included from /cvmfs/larsoft.opensciencegrid.org/products/gcc/v9_3_0/Linux64bit+3.10-2.17/bin/../lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../include/c++/9.3.0/string:40:
> /cvmfs/larsoft.opensciencegrid.org/products/gcc/v9_3_0/Linux64bit+3.10-2.17/bin/../lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../include/c++/9.3.0/bits/char_traits.h:236:14: error:
> use of undeclared identifier '__builtin_is_constant_evaluated'
> return __builtin_is_constant_evaluated();
>
> Which is totally crazy since the char_traits.h file looks like this:
>
> #ifdef _GLIBCXX_HAVE_BUILTIN_IS_CONSTANT_EVALUATED
> (void) __s;
> // In constexpr contexts all strings should be constant.
> return __builtin_is_constant_evaluated(); /// This is line 236
> #else
> while (__builtin_constant_p(*__s) && *__s)
> __s++;
> return __builtin_constant_p(*__s);
> #endif
>
> So I put in a gentler hack in SRTrueInteraction.h
>
> #ifdef __GNUC__
> #undef _GLIBCXX_HAVE_BUILTIN_IS_CONSTANT_EVALUATED
> #endif
> #include <string>
>
> This allows builds with e20, c7 and e26. The c14 build still fails with several errors.