### PR TITLE
Added caf::MINERvA class

### DIFF
--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -185,7 +185,9 @@
    <version ClassVersion="10" checksum="1443507594"/>
   </class>
 
-
+  <class name="caf::SRMINERvA"  ClassVersion="10">
+   <version ClassVersion="10" checksum="1718167975"/>
+  </class>
   <!-- - - - - - - - - - Truth - - - - - - - - - - - - - - - -->
 
   <class name="caf::SRTruthBranch" ClassVersion="10">


### PR DESCRIPTION
Added the caf::MINERvA class in "classes_def.xml" to store MINERvA. With this modification, MINERvA objects are properly stored into CAF root files.
[PR_caf.pdf](https://github.com/DUNE/duneanaobj/files/12176362/PR_caf.pdf)

