### PR TITLE
Additional variables to support truth-matching & ND-LAr ML-reco

### DIFF
--- a/duneanaobj/StandardRecord/Flat/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Flat/CMakeLists.txt
@@ -14,7 +14,12 @@ if(DEFINED CETMODULES_CURRENT_PROJECT_NAME)
                      LIBRARIES    ${ROOT_BASIC_LIB_LIST} ROOT::TreePlayer
                      )
 
-    install_headers(EXTRAS $ENV{MRB_BUILDDIR}/duneanaobj/duneanaobj/StandardRecord/Flat/FlatRecord.h $ENV{MRB_BUILDDIR}/duneanaobj/duneanaobj/StandardRecord/Flat/FwdDeclare.h)
+    if (DEFINED ENV{MRB_BUILDDIR} AND NOT "$ENV{MRB_BUILDDIR}" STREQUAL "")
+        set(builddir $ENV{MRB_BUILDDIR}/duneanaobj)
+    else()
+        set(builddir ${CMAKE_BINARY_DIR})
+    endif()
+    install_headers(EXTRAS ${builddir}/duneanaobj/StandardRecord/Flat/FlatRecord.h ${builddir}/duneanaobj/StandardRecord/Flat/FwdDeclare.h)
 else()
     add_library(duneanaobj_StandardRecordFlat
                 FlatRecord.cxx)

--- a/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
@@ -16,7 +16,14 @@ if(DEFINED CETMODULES_CURRENT_PROJECT_NAME)
     cet_make_library(LIBRARY_NAME duneanaobj_StandardRecordProxy
             SOURCE       SRProxy.cxx Instantiations.cxx
             LIBRARIES    ${ROOT_BASIC_LIB_LIST} ROOT::TreePlayer)
-    install_headers(EXTRAS $ENV{MRB_BUILDDIR}/duneanaobj/duneanaobj/StandardRecord/Proxy/SRProxy.h $ENV{MRB_BUILDDIR}/duneanaobj/duneanaobj/StandardRecord/Proxy/FwdDeclare.h)
+
+    if (DEFINED ENV{MRB_BUILDDIR} AND NOT "$ENV{MRB_BUILDDIR}" STREQUAL "")
+        message(STATUS "MRB_BUILDDIR = $ENV{MRB_BUILDDIR}")
+        set(builddir $ENV{MRB_BUILDDIR}/duneanaobj)
+    else()
+        set(builddir ${CMAKE_BINARY_DIR})
+    endif()
+    install_headers(EXTRAS ${builddir}/duneanaobj/StandardRecord/Proxy/SRProxy.h ${builddir}/duneanaobj/StandardRecord/Proxy/FwdDeclare.h)
 else()
     add_library(duneanaobj_StandardRecordProxy
                 SRProxy.cxx Instantiations.cxx)

--- a/duneanaobj/StandardRecord/SRInteraction.h
+++ b/duneanaobj/StandardRecord/SRInteraction.h
@@ -18,6 +18,8 @@ namespace caf
   class SRInteraction
   {
     public:
+      long int id = -1;
+
       /// Reconstructed vertex location (if any)
       SRVector3D vtx;
 

--- a/duneanaobj/StandardRecord/SRInteraction.h
+++ b/duneanaobj/StandardRecord/SRInteraction.h
@@ -35,6 +35,9 @@ namespace caf
       /// Collections of reconstructed particles
       SRRecoParticlesBranch part;
 
+      std::vector<std::size_t>    truth;              ///< Indices of SRTrueInteraction(s), if relevant (use this index in SRTruthBranch::nu to get them)
+      std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco interaction and each true interaction
+
   };
 
 } // caf

--- a/duneanaobj/StandardRecord/SRLorentzVector.cxx
+++ b/duneanaobj/StandardRecord/SRLorentzVector.cxx
@@ -7,6 +7,8 @@
 
 #include <limits>
 
+#include "TLorentzVector.h"
+
 namespace caf
 {
   SRLorentzVector::SRLorentzVector() :
@@ -24,6 +26,16 @@ namespace caf
   SRLorentzVector::operator TLorentzVector() const
   {
     return TLorentzVector(px, py, pz, E);
+  }
+
+  SRLorentzVector &SRLorentzVector::operator=(const TLorentzVector &vec)
+  {
+    E = vec.E();
+    px = vec.Px();
+    py = vec.Py();
+    pz = vec.Pz();
+
+    return *this;
   }
 
 } // end namespace caf

--- a/duneanaobj/StandardRecord/SRLorentzVector.h
+++ b/duneanaobj/StandardRecord/SRLorentzVector.h
@@ -37,6 +37,8 @@ namespace caf
       /// Recommend users convert back to TLorentzVector for boosts etc
       operator TLorentzVector() const;
 
+      SRLorentzVector & operator=(const TLorentzVector& vec);
+
       // For access as a position vector. For momentum use the member variables
       // directly.
       float T() const {return E;}

--- a/duneanaobj/StandardRecord/SRNDTrackAssn.h
+++ b/duneanaobj/StandardRecord/SRNDTrackAssn.h
@@ -17,10 +17,10 @@ namespace caf
       static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
 
     public:
-      SRNDLArID     larid;     ///< ND-LAr track identifier.  Get the actual SRTrack object using SRNDLAr::Reco<Track>() with this ID, e.g.`sr.nd.lar.Reco<Track>(sr.nd.trkmatch.extrap[1].larid)`
-      SRTMSID     tmsid;     ///< TMS track identifier.   Get the actual SRTrack object using SRTMS::Track() with this ID, e.g.`sr.nd.lar.Track(sr.nd.trkmatch.extrap[1].tmsid)`
-      SRMINERvA minervaid; ///< MINERvA track identifier.
-      SRGArID     garid;     ///< GAr track identifier.
+      SRNDLArID  larid;     ///< ND-LAr track identifier.  Get the actual SRTrack object using SRNDLAr::Reco<Track>() with this ID, e.g.`sr.nd.lar.Reco<Track>(sr.nd.trkmatch.extrap[1].larid)`
+      SRTMSID    tmsid;     ///< TMS track identifier.   Get the actual SRTrack object using SRTMS::Track() with this ID, e.g.`sr.nd.lar.Track(sr.nd.trkmatch.extrap[1].tmsid)`
+      SRMINERvA  minervaid; ///< MINERvA track identifier.
+      SRGArID    garid;     ///< GAr track identifier.
 
 
       float transdispl  = NaN;     ///< perpendicular distance between the two tracks at longitudinal position of matching point

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -41,7 +41,8 @@ namespace caf
       //       or should this be the responsibility of the reco module?  (what about stuff that crosses detector boundaries?...)
       bool        contained = false;
 
-      TrueParticleID truth;                       ///< Associated SRTrueParticle, if relevant (use SRTruthBranch::Particle() with this ID to grab it)
+      std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
+      std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco particle and true particle
   };
 
 } // caf

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -30,12 +30,12 @@ namespace caf
 
       float       score    = NaN;                     ///< PID score for this particle, if relevant
 
-      float       E        = NaN;                     ///< Reconstructed energy for this particle
+      float       E        = NaN;                     ///< Reconstructed energy for this particle [GeV]
       PartEMethod E_method = PartEMethod::kUnknownMethod;   ///< Method used to determine energy for the particle
       SRVector3D  p;                                  ///< Reconstructed momentum for this particle
 
-      SRVector3D  start;                              ///< Reconstructed start point of this particle
-      SRVector3D  end;                                ///< Reconstructed end point of this particle, if that makes sense
+      SRVector3D  start;                              ///< Reconstructed start point of this particle [cm]
+      SRVector3D  end;                                ///< Reconstructed end point of this particle, if that makes sense [cm]
 
       // todo: would we prefer some kind of "extents" thing so that we can make a decision about containment later?
       //       or should this be the responsibility of the reco module?  (what about stuff that crosses detector boundaries?...)

--- a/duneanaobj/StandardRecord/SRShower.h
+++ b/duneanaobj/StandardRecord/SRShower.h
@@ -20,7 +20,7 @@ namespace caf
       SRVector3D direction;  ///< Shower 3D end point [cm]
       float Evis = -999.;    ///< Visible energy in voxels corresponding to this shower
 
-      SRTrueParticle truth;  ///< Best-match GEANT truth particle for this track
+      TrueParticleID truth;  ///< Best-match GEANT truth particle for this track.  Use SRTruthBranch::Particle() to obtain this particle
   };
 
 }

--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -7,6 +7,7 @@
 #ifndef DUNEANAOBJ_SRTRACK_H
 #define DUNEANAOBJ_SRTRACK_H
 
+#include "duneanaobj/StandardRecord/SREnums.h"
 #include "duneanaobj/StandardRecord/SRVector3D.h"
 #include "duneanaobj/StandardRecord/SRTrueParticle.h"
 
@@ -33,7 +34,7 @@ namespace caf
 
       float E = NaN;         ///< Track energy estimate in MeV
 
-      SRTrueParticle truth; ///< Best-match GEANT truth particle for this track
+      TrueParticleID truth;  ///< Best-match GEANT truth particle for this track.  Use SRTruthBranch::Particle() to obtain this particle
   };
 
 }

--- a/duneanaobj/StandardRecord/SRTrueInteraction.h
+++ b/duneanaobj/StandardRecord/SRTrueInteraction.h
@@ -33,7 +33,12 @@ namespace caf
        static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
 
      public:
-       int   id      = -1;         ///< Interaction ID == GENIE event record number (== genie::NtpMCRecHeader::ievent)
+       long int  id       = -1;   ///< Interaction ID == 'vertexID' from edep-sim (ND) or GENIE record id (FD)
+       
+       /// Index of interaction in GENIE tree.
+       /// Note: for ND, check `id` to determine whether
+       /// it's the tree for contained nus (<1e9) or rock/hall nus (>1e9)
+       long int  genieIdx = -1;
 
        int   pdg     = 0;         ///< PDG code of probe particle
        int   pdgorig = 0;         ///< Initial (unoscillated) PDG code of probe neutrino (may be different than `pdg` if this file is a 'swap' file)

--- a/duneanaobj/StandardRecord/SRTrueInteraction.h
+++ b/duneanaobj/StandardRecord/SRTrueInteraction.h
@@ -33,7 +33,7 @@ namespace caf
        static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
 
      public:
-       int   id      = 0;         ///< Interaction ID == GENIE event record number (== genie::NtpMCRecHeader::ievent)
+       int   id      = -1;         ///< Interaction ID == GENIE event record number (== genie::NtpMCRecHeader::ievent)
 
        int   pdg     = 0;         ///< PDG code of probe particle
        int   pdgorig = 0;         ///< Initial (unoscillated) PDG code of probe neutrino (may be different than `pdg` if this file is a 'swap' file)

--- a/duneanaobj/StandardRecord/SRTrueInteraction.h
+++ b/duneanaobj/StandardRecord/SRTrueInteraction.h
@@ -33,7 +33,7 @@ namespace caf
        static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
 
      public:
-       bool  isvtxcont = false;   ///< Is true vertex is within detector?  If not, might be a rock particle or cosmic
+       int   id      = 0;         ///< Interaction ID == GENIE event record number (== genie::NtpMCRecHeader::ievent)
 
        int   pdg     = 0;         ///< PDG code of probe particle
        int   pdgorig = 0;         ///< Initial (unoscillated) PDG code of probe neutrino (may be different than `pdg` if this file is a 'swap' file)
@@ -50,17 +50,16 @@ namespace caf
        float       E         = NaN; ///< True energy [GeV]
        SRVector3D  vtx;             ///< Interaction vertex position in detector coord. [cm]
        SRVector3D  momentum;        ///< Neutrino three-momentum
-       SRVector3D  position;        ///< Neutrino interaction position
+       bool  isvtxcont = false;     ///< Is true vertex is within detector?  If not, might be a rock particle or cosmic
 
        float time         = NaN;    ///< True interaction time
-       float bjorkenX     = NaN;    ///< Bjorken x = (k-k')^2/(2*p.q) [Dimensionless]
+       float bjorkenX     = NaN;    ///< Bjorken x = (k-k')^2/(2*p.q) = Q^2/(2*Mnuc*q0) [Dimensionless]
        float inelasticity = NaN;    ///< Inelasticity y = (p.q) / (k.p) = q0 / Enu
-       float Q2           = NaN;    ///< Invariant four-momentum transfer from lepton to nuclear system
+       float Q2           = NaN;    ///< Invariant four-momentum transfer from lepton to nuclear system, Q^2 = -(nu - lep)^2
        float q0           = NaN;    ///< Energy transferred from lepton to nuclear system (in lab frame)
        float modq         = NaN;    ///< Magnitude of three-momentum transferred from lepton to nuclear system, |q| (in lab frame)
-       float W            = NaN;    ///< Hadronic invariant mass W [GeV^2]
+       float W            = NaN;    ///< Hadronic invariant mass W [GeV^2].  "Experimental W" in GENIE parlance, W^2 = M^2 + 2*Mnuc*q0 +|q|^2
        float t            = NaN;    ///< Kinematic t
-       float baseline     = NaN;    ///< Distance from decay to interaction [m]
 
        // GENIE truth stuff
        bool  ischarm    = false;    ///< Did neutrino scatter from a charmed quark?
@@ -70,6 +69,7 @@ namespace caf
 
        float genweight = NaN;       ///< Weight, if any, assigned by the generator
 
+       float baseline             = NaN; ///< Distance from decay to interaction [m]
        SRVector3D prod_vtx;              ///< Neutrino production vertex [cm; beam coordinates]
        SRVector3D parent_dcy_mom;        ///< Neutrino parent momentum at decay [GeV; beam coordinates]
        int        parent_dcy_mode = -1;  ///< Parent hadron/muon decay mode

--- a/duneanaobj/StandardRecord/SRTrueParticle.h
+++ b/duneanaobj/StandardRecord/SRTrueParticle.h
@@ -25,10 +25,10 @@ namespace caf
       static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
 
     public:
-      int      pdg             = 0;     ///< Particle
-      int      G4ID            = -1;    ///< ID of the particle (taken from GEANT4 -- -1 if this particle is not propogated by G4)
-      int      interaction_id  = -1;    ///< True interaction ID of the source of this particle
-      float    time            = NaN;   ///< Generation time at true interaction vertex [ns]
+      int       pdg             = 0;     ///< Particle
+      int       G4ID            = -1;    ///< ID of the particle (taken from GEANT4 -- -1 if this particle is not propogated by G4)
+      long int  interaction_id  = -1;    ///< True interaction ID (edep-sim 'vertexID' for ND, or GENIe record number for FD) of the source of this particle
+      float     time            = NaN;   ///< Generation time at true interaction vertex [ns]
 
       TrueParticleID  ancestor_id;      ///< The primary particle this particle descended from, if relevant
 

--- a/duneanaobj/StandardRecord/SRTrueParticle.h
+++ b/duneanaobj/StandardRecord/SRTrueParticle.h
@@ -36,7 +36,7 @@ namespace caf
       SRVector3D      start_pos;        ///< Particle generation position [cm]
       SRVector3D      end_pos;          ///< Particle end position (decay, interaction, stop) [cm]
 
-      unsigned int parent;                 ///< GEANT4 trackID of parent particle from this particle
+      int parent               = -1;       ///< GEANT4 trackID of parent particle from this particle
       std::vector<unsigned int> daughters; ///< GEANT4 trackIDs of daughter particles from this particle
 
       G4Process   start_process;   ///< GEANT4 process that created this particle (kPrimary means 'came from GENIE')

--- a/duneanaobj/StandardRecord/SRVector3D.cxx
+++ b/duneanaobj/StandardRecord/SRVector3D.cxx
@@ -36,6 +36,12 @@ namespace caf
     return TVector3(x, y, z);
   }
 
+  SRVector3D &SRVector3D::operator=(const TVector3& vec)
+  {
+    SetXYZ(vec.X(), vec.Y(), vec.Z());
+    return *this;
+  }
+
 }
 
 std::ostream &operator<<(std::ostream &stream, const caf::SRVector3D &vec)

--- a/duneanaobj/StandardRecord/SRVector3D.h
+++ b/duneanaobj/StandardRecord/SRVector3D.h
@@ -38,8 +38,9 @@ namespace caf
       void SetXYZ(float x, float y, float z);
 
 #if !defined(__GCCXML__) && !defined(__castxml__)
-      /// Easy conversion back to TVector3
+      /// Easy conversion to and from TVector3
       operator TVector3() const;
+      SRVector3D & operator=(const TVector3& vec);
 
       void SetX(float _x){x = _x;}
       void SetY(float _y){y = _y;}

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -209,7 +209,8 @@
    <version ClassVersion="10" checksum="2608785459"/>
   </class>
 
-  <class name="caf::SRTrueInteraction" ClassVersion="15">
+  <class name="caf::SRTrueInteraction" ClassVersion="16">
+   <version ClassVersion="16" checksum="358248003"/>
    <version ClassVersion="15" checksum="880834593"/>
    <version ClassVersion="14" checksum="2603312895"/>
    <version ClassVersion="13" checksum="831273903"/>
@@ -218,7 +219,12 @@
    <version ClassVersion="10" checksum="1298199261"/>
   </class>
 
-  <class name="caf::SRTrueParticle" ClassVersion="13">
+  <class name="caf::TrueParticleID" ClassVersion="10">
+   <version ClassVersion="10" checksum="2662412328"/>
+  </class>
+
+  <class name="caf::SRTrueParticle" ClassVersion="14">
+   <version ClassVersion="14" checksum="1907525372"/>
    <version ClassVersion="13" checksum="1852140823"/>
    <version ClassVersion="12" checksum="941873740"/>
    <version ClassVersion="11" checksum="4112437168"/>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -207,7 +207,9 @@
    <version ClassVersion="10" checksum="2608785459"/>
   </class>
 
-  <class name="caf::SRTrueInteraction" ClassVersion="12">
+  <class name="caf::SRTrueInteraction" ClassVersion="14">
+   <version ClassVersion="14" checksum="2603312895"/>
+   <version ClassVersion="13" checksum="831273903"/>
    <version ClassVersion="12" checksum="27666301"/>
    <version ClassVersion="11" checksum="1216771862"/>
    <version ClassVersion="10" checksum="1298199261"/>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -61,7 +61,8 @@
    <version ClassVersion="10" checksum="1911225621"/>
   </class>
 
-  <class name="caf::SRInteraction" ClassVersion="10">
+  <class name="caf::SRInteraction" ClassVersion="11">
+   <version ClassVersion="11" checksum="1154108588"/>
    <version ClassVersion="10" checksum="2468658506"/>
   </class>
 
@@ -86,7 +87,8 @@
    <version ClassVersion="10" checksum="684361603"/>
   </class>
 
-  <class name="caf::SRRecoParticle" ClassVersion="13">
+  <class name="caf::SRRecoParticle" ClassVersion="14">
+   <version ClassVersion="14" checksum="621972464"/>
    <version ClassVersion="13" checksum="2634132066"/>
    <version ClassVersion="12" checksum="223390088"/>
    <version ClassVersion="11" checksum="1827982951"/>
@@ -207,7 +209,8 @@
    <version ClassVersion="10" checksum="2608785459"/>
   </class>
 
-  <class name="caf::SRTrueInteraction" ClassVersion="14">
+  <class name="caf::SRTrueInteraction" ClassVersion="15">
+   <version ClassVersion="15" checksum="880834593"/>
    <version ClassVersion="14" checksum="2603312895"/>
    <version ClassVersion="13" checksum="831273903"/>
    <version ClassVersion="12" checksum="27666301"/>
@@ -215,7 +218,8 @@
    <version ClassVersion="10" checksum="1298199261"/>
   </class>
 
-  <class name="caf::SRTrueParticle" ClassVersion="12">
+  <class name="caf::SRTrueParticle" ClassVersion="13">
+   <version ClassVersion="13" checksum="1852140823"/>
    <version ClassVersion="12" checksum="941873740"/>
    <version ClassVersion="11" checksum="4112437168"/>
     <version ClassVersion="10" checksum="3381095522"/>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -57,7 +57,19 @@
    <version ClassVersion="10" checksum="2681983110"/>
   </class>
 
-  <class name="caf::SRNeutrinoHypothesisBranch" ClassVersion="10">
+  <class name="caf::SRInteractionBranch" ClassVersion="10">
+   <version ClassVersion="10" checksum="1911225621"/>
+  </class>
+
+  <class name="caf::SRInteraction" ClassVersion="10">
+   <version ClassVersion="10" checksum="2468658506"/>
+  </class>
+
+  <class name="caf::SRDirectionBranch" ClassVersion="10">
+   <version ClassVersion="10" checksum="2433306859"/>
+  </class>
+
+    <class name="caf::SRNeutrinoHypothesisBranch" ClassVersion="10">
    <version ClassVersion="10" checksum="3470794688"/>
   </class>
 
@@ -88,7 +100,8 @@
 
   <!-- - - - - - - - Types used in det-specific situations - - - - -->
 
-  <class name="caf::SRTrack" ClassVersion="16">
+  <class name="caf::SRTrack" ClassVersion="17">
+   <version ClassVersion="17" checksum="3391134008"/>
    <version ClassVersion="16" checksum="3368125268"/>
    <version ClassVersion="15" checksum="0"/>
    <version ClassVersion="14" checksum="514514930"/>
@@ -101,7 +114,8 @@
   <class name="std::vector<caf::SRTrack>">
   </class>
 
-  <class name="caf::SRShower" ClassVersion="13">
+  <class name="caf::SRShower" ClassVersion="14">
+   <version ClassVersion="14" checksum="772507687"/>
    <version ClassVersion="13" checksum="749498947"/>
    <version ClassVersion="12" checksum="0"/>
    <version ClassVersion="11" checksum="749498947"/>
@@ -155,7 +169,8 @@
    <version ClassVersion="10" checksum="2529880392"/>
   </class>
 
-  <class name="caf::SRGArTrack" ClassVersion="12">
+  <class name="caf::SRGArTrack" ClassVersion="13">
+   <version ClassVersion="13" checksum="3987769238"/>
    <version ClassVersion="12" checksum="3869515338"/>
    <version ClassVersion="11" checksum="2689178119"/>
    <version ClassVersion="10" checksum="4044067765"/>


### PR DESCRIPTION
This PR mainly adds a few new fields needed to store truth info for the pass-through pipeline from ND-LAr ML-reco.  It also corrects a few bugs around the edges (e.g.: the oversight that pretended a reco particle will only ever match to a single true particle).