### PR TITLE
follow a suggestion from Chris Green in Redmine ticket #28197

### DIFF
--- a/duneanaobj/StandardRecord/Flat/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Flat/CMakeLists.txt
@@ -3,7 +3,7 @@ FILE(GLOB SR_DEPENDENCIES duneanaobj/StandardRecord/*.h)
 add_custom_command(# Rebuild if anything in StandardRecord/ changes
                    DEPENDS ${SR_DEPENDENCIES}
                    OUTPUT FlatRecord.cxx FlatRecord.h FwdDeclare.h
-                   COMMAND gen_srproxy --flat -i duneanaobj/StandardRecord/StandardRecord.h -o FlatRecord --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Flat/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --extra-cflags ' -D_Float16=short'
+                   COMMAND gen_srproxy --flat -i duneanaobj/StandardRecord/StandardRecord.h -o FlatRecord --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Flat/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --extra-cflags ' -D_Float16=short -fsized-deallocation'
   )
 
 include_directories($ENV{SRPROXY_INC})

--- a/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
@@ -3,7 +3,7 @@ FILE(GLOB SR_DEPENDENCIES duneanaobj/StandardRecord/*.h)
 add_custom_command(# Rebuild if anything in StandardRecord/ changes
                    DEPENDS ${SR_DEPENDENCIES}
                    OUTPUT SRProxy.cxx SRProxy.h FwdDeclare.h
-                   COMMAND gen_srproxy -i duneanaobj/StandardRecord/StandardRecord.h -o SRProxy --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Proxy/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --epilog-fwd ${CMAKE_CURRENT_SOURCE_DIR}/EpilogFwd.h --extra-cflags ' -D_Float16=short'
+                   COMMAND gen_srproxy -i duneanaobj/StandardRecord/StandardRecord.h -o SRProxy --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Proxy/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --epilog-fwd ${CMAKE_CURRENT_SOURCE_DIR}/EpilogFwd.h --extra-cflags ' -D_Float16=short -fsized-deallocation'
   )
 
 include_directories($ENV{SRPROXY_INC})


### PR DESCRIPTION
Following discussion in

https://cdcvs.fnal.gov/redmine/issues/28197

I have modified the CMakeLists.txt files in duneanaobj/StandardRecord/[Flat|Proxy] to include the C flag -fsized-deallocation.  The product now builds under e20, c7, e26 and c14 without hacks in the source.