### PR TITLE
Finish automatic Doxygen deployment

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -733,7 +733,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = CAFAna/Core
+INPUT                  = duneanaobj/StandardRecord
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ CAFs are intended to have a low barrier-to-entry and be easy to use.
 The only requirements for reading them are ROOT and the format description,
 i.e., the `StandardRecord` object contained in this package.
 
+If you're just looking for documentation on what's in a `StandardRecord`, 
+have a look at the [Doxygen documentation pages](https://dune.github.io/duneanaobj/classcaf_1_1StandardRecord.html)
+automatically generated from this repository.
+(They are automatically updated whenever the `main` branch is using a GitHub Actions workflow.)
+
 ## Setting up `duneanaobj` for use 
 
 In order to work with CAFs, you'll need to have the libraries from this package accessible to the software you want to read the CAFs with.

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -12,32 +12,33 @@
 
 namespace caf
 {
+  /// Known detectors in CAFs.
   enum Detector : std::size_t
   {
     kUnknownDet = 0,
 
     // full NDs in Phase I or Phase II
-    kND_LAr  = 1,  /// 35-module liquid argon TPC  (forms part of movable PRISM detector concept)
-    kND_TMS  = 2,  /// magnetized spectrometer/calorimeter (forms part of movable PRISM detector concept in Phase I)
-    kND_SAND = 3, /// scintillator tracker and calorimeter, fixed on-axis in beam
-    kND_GAr  = 4,  /// high-pressure gaseous argon TPC (forms part of movable PRISM detector concept in Phase II)
+    kND_LAr  = 1,  ///< 35-module liquid argon TPC  (forms part of movable PRISM detector concept)
+    kND_TMS  = 2,  ///< magnetized spectrometer/calorimeter (forms part of movable PRISM detector concept in Phase I)
+    kND_SAND = 3,  ///< scintillator tracker and calorimeter, fixed on-axis in beam
+    kND_GAr  = 4,  ///< high-pressure gaseous argon TPC (forms part of movable PRISM detector concept in Phase II)
 
     // ND prototypes (more to add?)
-    k2x2     = 5,  /// ND-LAr prototype
-    kMINERvA = 6,     /// tracker & muon veto for 2x2; repurposed former MINERvA detector components
+    k2x2     = 5,  ///< ND-LAr prototype
+    kMINERvA = 6,  ///< tracker & muon veto for 2x2; repurposed former MINERvA detector components
 
     // leaving some space for expansion ...
 
     // full FDs (Phase II modules TBD...)
-    kFD_HD = 10, /// Horizontal drift (a.k.a. module 1)
-    kFD_VD = 11,        /// Vertical drift (a.k.a. module 2)
+    kFD_HD = 10,   ///< Horizontal drift (a.k.a. module 1)
+    kFD_VD = 11,   ///< Vertical drift (a.k.a. module 2)
 
     // space for modules 3 and 4...
 
     // FD prototypes  (we don't have any ProtoDUNE-VD data that will be CAFfed?)
-    kProtoDUNE = 15,  /// Horizontal drift prototype
+    kProtoDUNE = 15,  ///< Horizontal drift prototype
 
-    _kLastDetector = 24  // to use in bitset sizing.  make it big enough that we'll never have to expand it ---> future-proof CAFs
+    _kLastDetector = 24  ///< to use in bitset sizing.  make it big enough that we'll never have to expand it ---> future-proof CAFs
   };
 
 
@@ -50,12 +51,13 @@ namespace caf
     kNEUT             = 3
   };
 
+  /// Methods for reconstructing particle energies.
   enum PartEMethod
   {
     kUnknownMethod,
-    kRange,
-    kMCS,
-    kCalorimetry,
+    kRange,         ///< Amount of material traversed by particle
+    kMCS,           ///< Multiple scattering
+    kCalorimetry,   ///< Observed energy deposited in active volume
   };
 
   /// \brief Neutrino interaction categories.
@@ -99,12 +101,14 @@ namespace caf
       int      part = -1;       ///< Index of SRParticle in the SRInteraction
   };
 
+  /// Which reconstruction toolkit was used to reconstruct this FD event?
   enum FD_RECO_STACK
   {
     kUnknownFDReco,
     kPandoraFD
   };
 
+  /// Which reconstruction toolkit was used to reconstruct this ND event?
   enum NDLAR_RECO_STACK
   {
     kUnknownNDLArReco,


### PR DESCRIPTION
A supplement to #29 (which I manually pushed without a review because it is difficult to test the configuration without the base configuration being on `main`).  Includes a last fix to the configuration so that it will actually produce Doxygen pages as well as some spruce-ups to the `enum` documentation that I used to test the Doxygen output.