### PR TITLE
Small additions to fit DUNE FD needs

### DIFF
--- a/duneanaobj/StandardRecord/SRCVNScoreBranch.h
+++ b/duneanaobj/StandardRecord/SRCVNScoreBranch.h
@@ -16,7 +16,7 @@ namespace caf
       static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
 
     public:
-      bool isnubar = false;
+      float isnubar = NaN;
 
       float nue   = NaN;
       float numu  = NaN;

--- a/duneanaobj/StandardRecord/SRNeutrinoEnergyBranch.h
+++ b/duneanaobj/StandardRecord/SRNeutrinoEnergyBranch.h
@@ -19,6 +19,9 @@ namespace caf
     public:
       float calo     = NaN;  ///< Calorimetric estimate using all hits
       float lep_calo = NaN;  ///< Lepton (longest track or largest shower) + calorimetric estimate from remaining hits
+      float mu_range = NaN;  ///< Muon (longest track) using the stopping range + calorimetric estimate from the remaining hits
+      float mu_mcs   = NaN;  ///< Muon (longest track) using the Multiple Coulomb Scattering + calorimetric estimate from the remaining hits
+      float e_calo   = NaN;  ///< Electron (highest energy shower) + calorimetric estimate from the remaining hits
       float regcnn   = NaN;  ///< Regression CNN (assumes nue hypothesis)
   };
 


### PR DESCRIPTION
This PR aims to add more Neutrino Energy Reconstruction fields to fit the various reconstruction methods used in the FD analysis and let the analyzer use the best method.

A second modification is the change of the CVN `isnubar` boolean field to a floating point number to actually store the CVN score and let the analyzer make the relevant cuts.