### PR TITLE
Feature/flash 

### DIFF
--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -9,6 +9,7 @@
 #define DUNEANAOBJ_SRENUMS_H
 
 #include <cstddef>
+#include <limits>
 
 namespace caf
 {
@@ -99,6 +100,20 @@ namespace caf
       int      ixn  = -1;       ///< Index of SRInteraction in the SRTruthBranch
       PartType type = kUnknown; ///< Which of the particle collections this particle lives in
       int      part = -1;       ///< Index of SRParticle in the SRInteraction
+  };
+  
+  class FlashMatch
+  {
+    private:
+
+      static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
+
+    public:
+    
+      int   id            = -1;  ///< id of the matched flash in SROpticalFlash
+      float time          = NaN; ///< time of the matched flash
+      float total_pe      = NaN; ///< total pe of the matched flash
+      float hypothesis_pe = NaN; ///< hypothesis pe from reconstruction for this interaction
   };
 
   /// Which reconstruction toolkit was used to reconstruct this FD event?

--- a/duneanaobj/StandardRecord/SRMeta.h
+++ b/duneanaobj/StandardRecord/SRMeta.h
@@ -18,10 +18,10 @@ namespace caf
     public:
       bool enabled = false;     ///< Does this detector have data present in this event?
 
-      unsigned int run    = 0;
-      unsigned int subrun = 0;
-      unsigned int event  = 0;
-      unsigned int subevt = 0;
+      int run    = -1;
+      int subrun = -1;
+      int event  = -1;
+      int subevt = -1;
 
       /// detector-dependent trigger type for the relevant readout window
       int triggertype = -1;

--- a/duneanaobj/StandardRecord/SRNDLAr.cxx
+++ b/duneanaobj/StandardRecord/SRNDLAr.cxx
@@ -5,8 +5,8 @@ namespace caf
   template <typename T>
   const T & SRNDLAr::Reco(const SRNDLArID& id)
   {
-    static_assert(std::is_same_v<T, SRTrack> || std::is_same_v<T, SRShower>, 
-                  "Reco() only knows about SRTrack, SRShower");
+    static_assert(std::is_same_v<T, SRTrack> || std::is_same_v<T, SRShower>,
+                  "Reco() only knows about SRTrack and SRShower");
 
     const std::vector<SRNDLArInt> * ints = nullptr;
     if (id.reco == kDeepLearnPhys)

--- a/duneanaobj/StandardRecord/SRNDLAr.cxx
+++ b/duneanaobj/StandardRecord/SRNDLAr.cxx
@@ -5,8 +5,8 @@ namespace caf
   template <typename T>
   const T & SRNDLAr::Reco(const SRNDLArID& id)
   {
-    static_assert(std::is_same_v<T, SRTrack> || std::is_same_v<T, SRShower>,
-                  "Reco() only knows about SRTrack and SRShower!");
+    static_assert(std::is_same_v<T, SRTrack> || std::is_same_v<T, SRShower>, 
+                  "Reco() only knows about SRTrack, SRShower");
 
     const std::vector<SRNDLArInt> * ints = nullptr;
     if (id.reco == kDeepLearnPhys)

--- a/duneanaobj/StandardRecord/SRNDLAr.cxx
+++ b/duneanaobj/StandardRecord/SRNDLAr.cxx
@@ -6,7 +6,7 @@ namespace caf
   const T & SRNDLAr::Reco(const SRNDLArID& id)
   {
     static_assert(std::is_same_v<T, SRTrack> || std::is_same_v<T, SRShower>,
-                  "Reco() only knows about SRTrack and SRShower");
+                  "Reco() only knows about SRTrack and SRShower!");
 
     const std::vector<SRNDLArInt> * ints = nullptr;
     if (id.reco == kDeepLearnPhys)

--- a/duneanaobj/StandardRecord/SRNDLAr.h
+++ b/duneanaobj/StandardRecord/SRNDLAr.h
@@ -9,6 +9,7 @@
 
 #include "duneanaobj/StandardRecord/SRTrack.h"
 #include "duneanaobj/StandardRecord/SRShower.h"
+#include "duneanaobj/StandardRecord/SROpticalFlash.h"
 
 namespace caf
 {
@@ -21,6 +22,7 @@ namespace caf
 
       std::vector<SRShower> showers;
       std::size_t           nshowers = 0;
+      
   };
 
   /// The information needed to uniquely identify an ND-LAr reco object
@@ -40,7 +42,8 @@ namespace caf
       std::size_t ndlp = 0;
       std::vector<SRNDLArInt> pandora;   ///< Reconstructed interactions from Pandora
       std::size_t npandora = 0;
-
+      std::vector<SROpticalFlash> flashes;      ///< Collection of flashes
+      std::size_t                 nflashes = 0;
       /// Convenience function for use mainly with SRNDTrackAssn.
       /// Given a specific reco pathway (specified with a SRNDLAr::RECO_STACK value),
       /// an interaction index, and a track index, return the associated reco object

--- a/duneanaobj/StandardRecord/SRNDLAr.h
+++ b/duneanaobj/StandardRecord/SRNDLAr.h
@@ -23,7 +23,7 @@ namespace caf
       std::vector<SRShower> showers;
       std::size_t           nshowers = 0;
       
-      std::vector<FlashMatch> flash;        ///< Associated SROpticalFlash
+      std::vector<FlashMatch> flash;        ///< Attributes of matched flash
       
   };
 

--- a/duneanaobj/StandardRecord/SRNDLAr.h
+++ b/duneanaobj/StandardRecord/SRNDLAr.h
@@ -23,6 +23,8 @@ namespace caf
       std::vector<SRShower> showers;
       std::size_t           nshowers = 0;
       
+      std::vector<FlashMatch> flash;        ///< Associated SROpticalFlash
+      
   };
 
   /// The information needed to uniquely identify an ND-LAr reco object

--- a/duneanaobj/StandardRecord/SROpticalFlash.h
+++ b/duneanaobj/StandardRecord/SROpticalFlash.h
@@ -20,7 +20,7 @@ namespace caf
     public:
       int    id            = -1;     ///< id of the flash>
       int    tpc_id        = -1;     ///< id of the TPC>
-      double time          = NaN;    ///< time of the flash w.r.t. trigger time time in s
+      double time          = NaN;    ///< time of the flash w.r.t. trigger time in s
       double time_width    = NaN;    ///< width of the flash in s
       float  total_pe      = NaN;    ///< total photoelectrons recorded by all the channels
       

--- a/duneanaobj/StandardRecord/SROpticalFlash.h
+++ b/duneanaobj/StandardRecord/SROpticalFlash.h
@@ -10,7 +10,7 @@
 
 namespace caf
 {
-  /// \brief Reconstructed optical flash candidate
+  /// \brief optical flash candidate
   class SROpticalFlash
   {
     private:
@@ -20,14 +20,12 @@ namespace caf
     public:
       int    id            = -1;     ///< id of the flash>
       int    tpc_id        = -1;     ///< id of the TPC>
-      bool   on_beam_time  = false;  ///< is the flash on time with the beam?
       double time          = NaN;    ///< time of the flash w.r.t. trigger time time in s
       double time_width    = NaN;    ///< width of the flash in s
       float  total_pe      = NaN;    ///< total photoelectrons recorded by all the channels
-      std::vector<float> pe_per_channel;    ///< number of photoelectrons per channel
       
   };
 
 } // caf
 
-#endif //DUNEANAOBJ_SRRECOOPTICALFLASH_H
+#endif //DUNEANAOBJ_SROPTICALFLASH_H

--- a/duneanaobj/StandardRecord/SROpticalFlash.h
+++ b/duneanaobj/StandardRecord/SROpticalFlash.h
@@ -1,0 +1,33 @@
+////////////////////////////////////////////////////////////////////////
+/// \file    SROpticalFlash.h
+/// \brief   A general optical flash container
+/// \author  S. Kumaran <s.kumaran@uci.edu>
+
+
+#ifndef DUNEANAOBJ_SROPTICALFLASH_H
+#define DUNEANAOBJ_SROPTICALFLASH_H
+
+
+namespace caf
+{
+  /// \brief Reconstructed optical flash candidate
+  class SROpticalFlash
+  {
+    private:
+      // make the uses of it below more readable
+      static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
+    
+    public:
+      int    id            = -1;     ///< id of the flash>
+      int    tpc_id        = -1;     ///< id of the TPC>
+      bool   on_beam_time  = false;  ///< is the flash on time with the beam?
+      double time          = NaN;    ///< time of the flash w.r.t. trigger time time in s
+      double time_width    = NaN;    ///< width of the flash in s
+      float  total_pe      = NaN;    ///< total photoelectrons recorded by all the channels
+      std::vector<float> pe_per_channel;    ///< number of photoelectrons per channel
+      
+  };
+
+} // caf
+
+#endif //DUNEANAOBJ_SRRECOOPTICALFLASH_H

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -196,12 +196,15 @@
   <class name="std::vector<caf::SRNDTrackAssn>">
   </class>
 
-  <class name="caf::SRNDLAr" ClassVersion="11">
+  <class name="caf::SRNDLAr" ClassVersion="12">
+   <version ClassVersion="12" checksum="620685221"/>
    <version ClassVersion="11" checksum="1183768120"/>
    <version ClassVersion="10" checksum="3845592869"/>
   </class>
 
-  <class name="caf::SRNDLArInt" ClassVersion="10">
+  <class name="caf::SRNDLArInt" ClassVersion="12">
+   <version ClassVersion="12" checksum="947356810"/>
+   <version ClassVersion="11" checksum="1873045675"/>
    <version ClassVersion="10" checksum="947356810"/>
   </class>
 

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -42,7 +42,8 @@
    <version ClassVersion="10" checksum="175116589"/>
   </class>
 
-  <class name="caf::SRDetectorMeta" ClassVersion="11">
+  <class name="caf::SRDetectorMeta" ClassVersion="12">
+   <version ClassVersion="12" checksum="989983909"/>
    <version ClassVersion="11" checksum="810717581"/>
    <version ClassVersion="10" checksum="2557124789"/>
   </class>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -202,7 +202,8 @@
    <version ClassVersion="10" checksum="3845592869"/>
   </class>
 
-  <class name="caf::SRNDLArInt" ClassVersion="12">
+  <class name="caf::SRNDLArInt" ClassVersion="13">
+   <version ClassVersion="13" checksum="1379574528"/>
    <version ClassVersion="12" checksum="947356810"/>
    <version ClassVersion="11" checksum="1873045675"/>
    <version ClassVersion="10" checksum="947356810"/>


### PR DESCRIPTION
[Issue#40](https://github.com/DUNE/duneanaobj/issues/40):

1. New generic flash object (`SROpticalFlash`) to store flash information that can be used in any of the detectors. Currently added for NDLAr 2x2
2. Additional` FlashMatch` class in` SREnums.h` to store information about matched flashes in reco

Initialization of run, subrun, event, etc., with -1 so as to not have 0 for unmatched triggers in Mx2 [(Issue#39)](https://github.com/DUNE/duneanaobj/issues/39)