### PR TITLE
V03 06 01

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required (VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
 project(duneanaobj LANGUAGES CXX)
-set(${PROJECT_NAME}_CMAKE_PROJECT_VERSION_STRING 03.05.00)
+set(${PROJECT_NAME}_CMAKE_PROJECT_VERSION_STRING 03.06.01)
 
 message(STATUS "\n\n  ==========================   ${PROJECT_NAME}   ==========================")
 

--- a/duneanaobj/StandardRecord/SRMINERvA.h
+++ b/duneanaobj/StandardRecord/SRMINERvA.h
@@ -27,8 +27,9 @@ namespace caf
   };
 
   /// The information needed to uniquely identify a MINERvA reco object
-  struct SRMINERvAID
+  class SRMINERvAID
   {
+  public: 
     int        ixn  = -1;            ///< interaction ID
     int        idx  = -1;            ///< index in container
   };

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -184,11 +184,13 @@
    <version ClassVersion="10" checksum="764455914"/>
   </class>
 
-  <class name="caf::SRNDShowerAssn" ClassVersion="10">
+  <class name="caf::SRNDShowerAssn" ClassVersion="11">
+   <version ClassVersion="11" checksum="2148903847"/>
    <version ClassVersion="10" checksum="3398719456"/>
   </class>
 
-  <class name="caf::SRNDTrackAssn" ClassVersion="13">
+  <class name="caf::SRNDTrackAssn" ClassVersion="14">
+   <version ClassVersion="14" checksum="2659631828"/>
    <version ClassVersion="13" checksum="744508541"/>
    <version ClassVersion="12" checksum="3802670637"/>
    <version ClassVersion="11" checksum="0"/>


### PR DESCRIPTION
Update duneanaobj/StandardRecord/classes_def.xml which is automatically generated on the first round through an mrb build but needs a second round to actually use it.  This branch is called v03_06_01 so I can build a release with this version number.  I also fixed an issue with a class vs struct clash that clang caught.  When merging, you can delete the branch but then make a new tag for v03_06_01 so we still have that documented for the release.