### PR TITLE
Adding a few fields relevant for atm analysis

### DIFF
--- a/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
+++ b/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
@@ -21,6 +21,7 @@ namespace caf
   template class Proxy<FD_RECO_STACK>;
 
   template class Proxy<TrueParticleID::PartType>;
+  template class Proxy<RecoObjType>;
 
   template const SRTrueParticleProxy * FindParticle(const SRTruthBranchProxy & truth, const TrueParticleIDProxy & id);
   template const SRTrueInteractionProxy * FindInteraction(const SRTruthBranchProxy & truth,  long int id);

--- a/duneanaobj/StandardRecord/SRDirectionBranch.h
+++ b/duneanaobj/StandardRecord/SRDirectionBranch.h
@@ -17,6 +17,7 @@ namespace caf
     public:
       SRVector3D lngtrk;   ///< Direction reconstructed using the longest track
       SRVector3D heshw;    ///< Direction reconstructed using the highest-energy shower
+      SRVector3D calo;    ///< Direction reconstructed using the calorimetric energy depositions
 
       // add others as needed
   };

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -131,6 +131,17 @@ namespace caf
     kPandoraNDLAr
   };
 
+  /// \brief What is the type of the reconstructed object?
+  /// This is used to help with the association of reconstructed particles
+  /// to underlying reconstructed objects.
+  enum RecoObjType
+  {
+    kUnknownRecoObj = -1, ///< default value
+    kTrack          = 1,  ///< track
+    kShower         = 2,  ///< shower
+    kHitCollection  = 3,  ///< hit collection (mostly used to garbage collect all remaining hits)
+  }
+
 }
 
 

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -140,7 +140,7 @@ namespace caf
     kTrack          = 1,  ///< track
     kShower         = 2,  ///< shower
     kHitCollection  = 3,  ///< hit collection (mostly used to garbage collect all remaining hits)
-  }
+  };
 
 }
 

--- a/duneanaobj/StandardRecord/SRInteraction.cxx
+++ b/duneanaobj/StandardRecord/SRInteraction.cxx
@@ -1,0 +1,28 @@
+#include "duneanaobj/StandardRecord/SRInteraction.h"
+
+namespace caf
+{
+    bool SRInteraction::contained() const
+    {
+        for (const auto& p : part.dlp) {
+            if (!p.contained) {
+                return false;
+            }
+        }
+
+        for (const auto& p : part.pandora) {
+            if (!p.contained) {
+                return false;
+            }
+        }
+        for (const auto& p : part.pida) {
+            if (!p.contained) {
+                return false;
+            }
+        }
+
+        // Add other reco stacks as needed
+        // If all particles are contained, return true
+        return true;
+    }
+}

--- a/duneanaobj/StandardRecord/SRInteraction.h
+++ b/duneanaobj/StandardRecord/SRInteraction.h
@@ -38,6 +38,9 @@ namespace caf
       std::vector<std::size_t>    truth;              ///< Indices of SRTrueInteraction(s), if relevant (use this index in SRTruthBranch::nu to get them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco interaction and each true interaction
 
+      bool preselected = false; ///< Was this interaction preselected?  (Useful for workflows where CAFs are preprocessed / filtered in the process of making concatenated files)
+
+      bool contained() const; ///< Convenience function to check if the interaction is contained in the detector by checking the contained flag of all reco particles
   };
 
 } // caf

--- a/duneanaobj/StandardRecord/SRInteractionBranch.h
+++ b/duneanaobj/StandardRecord/SRInteractionBranch.h
@@ -21,7 +21,8 @@ namespace caf
       std::vector<SRInteraction> pandora;   ///< Interactions from Pandora reconstruction
       std::size_t npandora;
 
-
+      bool isselected = true; ///< Is this interaction selected by the analysis?
+      bool iscontained = true; ///< Is this interaction contained in the fiducial volume?
   };
 }
 

--- a/duneanaobj/StandardRecord/SRInteractionBranch.h
+++ b/duneanaobj/StandardRecord/SRInteractionBranch.h
@@ -20,9 +20,6 @@ namespace caf
 
       std::vector<SRInteraction> pandora;   ///< Interactions from Pandora reconstruction
       std::size_t npandora;
-
-      bool isselected = true; ///< Is this interaction selected by the analysis?
-      bool iscontained = true; ///< Is this interaction contained in the fiducial volume?
   };
 }
 

--- a/duneanaobj/StandardRecord/SRMeta.h
+++ b/duneanaobj/StandardRecord/SRMeta.h
@@ -26,6 +26,8 @@ namespace caf
       /// detector-dependent trigger type for the relevant readout window
       int triggertype = -1;
 
+      bool istriggered = true; ///< Was the event triggered by this detector?
+
       unsigned long int readoutstart_s   = 0;   ///< GPS time of trigger readout start, seconds part
       unsigned int      readoutstart_ns  = 0;   ///< GPS time of trigger readout start, nanoseconds part
       unsigned long int readoutend_s     = 0;   ///< GPS time of trigger readout end, seconds part

--- a/duneanaobj/StandardRecord/SRMeta.h
+++ b/duneanaobj/StandardRecord/SRMeta.h
@@ -26,7 +26,7 @@ namespace caf
       /// detector-dependent trigger type for the relevant readout window
       int triggertype = -1;
 
-      bool istriggered = true; ///< Was the event triggered by this detector?
+      bool triggered = true; ///< Was the event triggered by this detector?  (Useful in contexts where all simulated events are reconstructed, and triggering simulation was applied separately)
 
       unsigned long int readoutstart_s   = 0;   ///< GPS time of trigger readout start, seconds part
       unsigned int      readoutstart_ns  = 0;   ///< GPS time of trigger readout start, nanoseconds part

--- a/duneanaobj/StandardRecord/SRNeutrinoEnergyBranch.h
+++ b/duneanaobj/StandardRecord/SRNeutrinoEnergyBranch.h
@@ -22,6 +22,10 @@ namespace caf
       float mu_range = NaN;  ///< Muon (longest track) using the stopping range + calorimetric estimate from the remaining hits
       float mu_mcs   = NaN;  ///< Muon (longest track) using the Multiple Coulomb Scattering + calorimetric estimate from the remaining hits
       float e_calo   = NaN;  ///< Electron (highest energy shower) + calorimetric estimate from the remaining hits
+
+      float e_had = NaN;  ///< Hadronic energy (calorimetric estimate from all hits)
+      float e_lep = NaN;  ///< Leptonic energy (calorimetric estimate from all hits)
+
       float regcnn   = NaN;  ///< Regression CNN (assumes nue hypothesis)
   };
 

--- a/duneanaobj/StandardRecord/SRNeutrinoEnergyBranch.h
+++ b/duneanaobj/StandardRecord/SRNeutrinoEnergyBranch.h
@@ -23,8 +23,8 @@ namespace caf
       float mu_mcs   = NaN;  ///< Muon (longest track) using the Multiple Coulomb Scattering + calorimetric estimate from the remaining hits
       float e_calo   = NaN;  ///< Electron (highest energy shower) + calorimetric estimate from the remaining hits
 
-      float e_had = NaN;  ///< Hadronic energy (calorimetric estimate from all hits)
-      float e_lep = NaN;  ///< Leptonic energy (calorimetric estimate from all hits)
+      float e_had = NaN;  ///< NuE hadronic energy (calorimetric estimate from all non-primary-shower hits)
+      float mu_had = NaN;  ///< NuMu hadronic energy (calorimetric estimate from all non-primary-track hits)
 
       float regcnn   = NaN;  ///< Regression CNN (assumes nue hypothesis)
   };

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -40,6 +40,9 @@ namespace caf
       // todo: would we prefer some kind of "extents" thing so that we can make a decision about containment later?
       //       or should this be the responsibility of the reco module?  (what about stuff that crosses detector boundaries?...)
       bool        contained = false;
+      float       walldist = NaN;                   ///< Distance to the nearest wall of the detector [cm]
+
+      bool        istrack = false;                  ///< Is this a track or a shower?
 
       std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco particle and true particle

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -40,9 +40,9 @@ namespace caf
       // todo: would we prefer some kind of "extents" thing so that we can make a decision about containment later?
       //       or should this be the responsibility of the reco module?  (what about stuff that crosses detector boundaries?...)
       bool        contained = false;
-      float       walldist = NaN;                   ///< Distance to the nearest wall of the detector [cm]
+      float       walldist = NaN;                     ///< Closest distance to a detector wall [cm]
 
-      bool        istrack = false;                  ///< Is this a track or a shower?
+      RecoObjType origRecoObjType = RecoObjType::kUnknownRecoObj;  ///< Is this a track or a shower?
 
       std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco particle and true particle

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -42,7 +42,8 @@
    <version ClassVersion="10" checksum="175116589"/>
   </class>
 
-  <class name="caf::SRDetectorMeta" ClassVersion="12">
+  <class name="caf::SRDetectorMeta" ClassVersion="13">
+   <version ClassVersion="13" checksum="3486371400"/>
    <version ClassVersion="12" checksum="989983909"/>
    <version ClassVersion="11" checksum="810717581"/>
    <version ClassVersion="10" checksum="2557124789"/>
@@ -62,12 +63,14 @@
    <version ClassVersion="10" checksum="1911225621"/>
   </class>
 
-  <class name="caf::SRInteraction" ClassVersion="11">
+  <class name="caf::SRInteraction" ClassVersion="12">
+   <version ClassVersion="12" checksum="2000195876"/>
    <version ClassVersion="11" checksum="1154108588"/>
    <version ClassVersion="10" checksum="2468658506"/>
   </class>
 
-  <class name="caf::SRDirectionBranch" ClassVersion="10">
+  <class name="caf::SRDirectionBranch" ClassVersion="11">
+   <version ClassVersion="11" checksum="2218604191"/>
    <version ClassVersion="10" checksum="2433306859"/>
   </class>
 
@@ -82,7 +85,8 @@
    <version ClassVersion="10" checksum="1622576569"/>
   </class>
 
-  <class name="caf::SRNeutrinoEnergyBranch" ClassVersion="13">
+  <class name="caf::SRNeutrinoEnergyBranch" ClassVersion="14">
+   <version ClassVersion="14" checksum="1104425802"/>
    <version ClassVersion="13" checksum="3582001491"/>
    <version ClassVersion="12" checksum="1372801074"/>
    <version ClassVersion="11" checksum="3582001491"/>
@@ -94,7 +98,8 @@
    <version ClassVersion="10" checksum="684361603"/>
   </class>
 
-  <class name="caf::SRRecoParticle" ClassVersion="14">
+  <class name="caf::SRRecoParticle" ClassVersion="15">
+   <version ClassVersion="15" checksum="4130745478"/>
    <version ClassVersion="14" checksum="621972464"/>
    <version ClassVersion="13" checksum="2634132066"/>
    <version ClassVersion="12" checksum="223390088"/>


### PR DESCRIPTION
Add selection and containment flags to interaction and meta branches introduce energy estimates for hadronic and leptonic components.
The added fields should be relevant for any FD study.
