### PR TITLE
Adding some additional energy reconstruction for MCS LLHD

### DIFF
--- a/duneanaobj/StandardRecord/SRNeutrinoEnergyBranch.h
+++ b/duneanaobj/StandardRecord/SRNeutrinoEnergyBranch.h
@@ -17,11 +17,12 @@ namespace caf
       static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
 
     public:
-      float calo     = NaN;  ///< Calorimetric estimate using all hits
-      float lep_calo = NaN;  ///< Lepton (longest track or largest shower) + calorimetric estimate from remaining hits
-      float mu_range = NaN;  ///< Muon (longest track) using the stopping range + calorimetric estimate from the remaining hits
-      float mu_mcs   = NaN;  ///< Muon (longest track) using the Multiple Coulomb Scattering + calorimetric estimate from the remaining hits
-      float e_calo   = NaN;  ///< Electron (highest energy shower) + calorimetric estimate from the remaining hits
+      float calo        = NaN;  ///< Calorimetric estimate using all hits
+      float lep_calo    = NaN;  ///< Lepton (longest track or largest shower) + calorimetric estimate from remaining hits
+      float mu_range    = NaN;  ///< Muon (longest track) using the stopping range + calorimetric estimate from the remaining hits
+      float mu_mcs      = NaN;  ///< Muon (longest track) using the Multiple Coulomb Scattering (using chi2 fit) + calorimetric estimate from the remaining hits
+      float mu_mcs_llhd = NaN;  ///< Muon (longest track) using the Multiple Coulomb Scattering (using LLHD fit) + calorimetric estimate from the remaining hits
+      float e_calo      = NaN;  ///< Electron (highest energy shower) + calorimetric estimate from the remaining hits
 
       float e_had = NaN;  ///< NuE hadronic energy (calorimetric estimate from all non-primary-shower hits)
       float mu_had = NaN;  ///< NuMu hadronic energy (calorimetric estimate from all non-primary-track hits)

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -85,7 +85,8 @@
    <version ClassVersion="10" checksum="1622576569"/>
   </class>
 
-  <class name="caf::SRNeutrinoEnergyBranch" ClassVersion="14">
+  <class name="caf::SRNeutrinoEnergyBranch" ClassVersion="15">
+   <version ClassVersion="15" checksum="3331961107"/>
    <version ClassVersion="14" checksum="1104425802"/>
    <version ClassVersion="13" checksum="3582001491"/>
    <version ClassVersion="12" checksum="1372801074"/>


### PR DESCRIPTION
Minor modification to add a MCS LLHD reco energy. This will allow to produce CAFs for the LBL and atmospherics sample with the same workflow.
Sorry for "PR spam", this should be the last one before next FD CAF production hopefully.