### PR TITLE
Changes to duneanaobj for ND-LAr/TMS track matching in PR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required (VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
 project(duneanaobj LANGUAGES CXX)
-set(${PROJECT_NAME}_CMAKE_PROJECT_VERSION_STRING 03.06.01)
+set(${PROJECT_NAME}_CMAKE_PROJECT_VERSION_STRING 03.06.01b)
 
 message(STATUS "\n\n  ==========================   ${PROJECT_NAME}   ==========================")
 

--- a/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
+++ b/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
@@ -15,6 +15,7 @@ namespace caf
 
   template class Proxy<NDLAR_RECO_STACK>;
   template class Proxy<FD_RECO_STACK>;
+  template class Proxy<MatchType>;
 
   template class Proxy<TrueParticleID::PartType>;
 }

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -131,7 +131,7 @@ namespace caf
     kPandoraNDLAr
   };
 
-    enum MatchType
+    enum NDRecoMatchType
   {
     kUndeclared = 0, ///< default value
     kSimple = 1,  ///< match performed using Kate Hildebrandt's "simple" matching algorithm

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -131,6 +131,14 @@ namespace caf
     kPandoraNDLAr
   };
 
+    enum MatchType
+  {
+    kUndeclared = 0, ///< default value
+    kSimple = 1,  ///< match performed using Kate Hildebrandt's "simple" matching algorithm
+    kUniqueNoTime = 2,  ///< match performed using Quinton Weyrich's NDLArTMSUniqueMatchRecoFiller.cxx, without time
+    kUniqueWithTime = 3 ///< match performed using Quinton Weyrich's NDLArTMSUniqueMatchRecoFiller.cxx, with time
+  };
+
 }
 
 

--- a/duneanaobj/StandardRecord/SRNDTrackAssn.h
+++ b/duneanaobj/StandardRecord/SRNDTrackAssn.h
@@ -28,7 +28,7 @@ namespace caf
       float angdispl    = NaN;     ///< angular difference between the two tracks at longitudinal position of matching point
       float matchScore  = NaN;     ///< quantifies how well a LAr and TMS track match each other
 
-      MatchType matchType = caf::MatchType::kUndeclared; ///< specifies how the match was performed
+      NDRecoMatchType matchType = caf::NDRecoMatchType::kUndeclared; ///< specifies how the match was performed
 
       SRTrack trk;                   ///< new track object generated from synthesis of matched parts
   };

--- a/duneanaobj/StandardRecord/SRNDTrackAssn.h
+++ b/duneanaobj/StandardRecord/SRNDTrackAssn.h
@@ -8,6 +8,7 @@
 #include "duneanaobj/StandardRecord/SRTMS.h"
 #include "duneanaobj/StandardRecord/SRMINERvA.h"
 #include "duneanaobj/StandardRecord/SRGAr.h"
+#include "duneanaobj/StandardRecord/SREnums.h"
 
 namespace caf
 {
@@ -25,6 +26,9 @@ namespace caf
 
       float transdispl  = NaN;     ///< perpendicular distance between the two tracks at longitudinal position of matching point
       float angdispl    = NaN;     ///< angular difference between the two tracks at longitudinal position of matching point
+      float matchScore  = NaN;     ///< quantifies how well a LAr and TMS track match each other
+
+      MatchType matchType = caf::MatchType::kUndeclared; ///< specifies how the match was performed
 
       SRTrack trk;                   ///< new track object generated from synthesis of matched parts
   };

--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -24,6 +24,8 @@ namespace caf
       SRVector3D dir;        ///< Unit vector representing estimate of track direction *taken from start point*
       SRVector3D enddir;     ///< Unit vector representing estimate of track direction *taken from endpoint*
 
+      double time     = NaN;  ///< Time of track formation [ns]
+
       float Evis     = NaN;  ///< Visible energy in voxels corresponding to this track
 
       // Track characteristics

--- a/duneanaobj/StandardRecord/SRTrueParticle.h
+++ b/duneanaobj/StandardRecord/SRTrueParticle.h
@@ -28,7 +28,7 @@ namespace caf
       int       pdg             = 0;     ///< Particle
       int       G4ID            = -1;    ///< ID of the particle (taken from GEANT4 -- -1 if this particle is not propogated by G4)
       long int  interaction_id  = -1;    ///< True interaction ID (edep-sim 'vertexID' for ND, or GENIe record number for FD) of the source of this particle
-      float     time            = NaN;   ///< Generation time at true interaction vertex [ns]
+      double     time            = NaN;   ///< Generation time at true interaction vertex [ns]
 
       TrueParticleID  ancestor_id;      ///< The primary particle this particle descended from, if relevant
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -318,12 +318,12 @@ end_product_list
 #
 ####################################
 qualifier	root		srproxy	notes
-c14:debug	c14:p3915:debug	py3915
-c14:prof	c14:p3915:prof	py3915
-e20:debug	e20:p3915:debug	py3915
-e20:prof	e20:p3915:prof	py3915
-e26:debug	e26:p3915:debug	py3915
-e26:prof	e26:p3915:prof	py3915
+c14:debug	c14:p3913:debug	py3913
+c14:prof	c14:p3913:prof	py3913
+e20:debug	e20:p3913:debug	py3913
+e20:prof	e20:p3913:prof	py3913
+e26:debug	e26:p3913:debug	py3913
+e26:prof	e26:p3913:prof	py3913
 end_qualifier_list
 ####################################
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -260,7 +260,7 @@ libdir	fq_dir		lib
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-root		v6_28_12	-
+root		v6_26_06b	-
 srproxy		v00.44		-
 cetmodules	v3_22_02	-	only_for_build
 end_product_list


### PR DESCRIPTION
Changes to duneanaobj to allow NDLArTMSUniqueMatchRecoFiller.cxx (in upcoming ND CAFMaker pull request) to perform its track matching operations. These changes include adding time as an attribute to the SRTrack object and defining an enum which keeps track of which algorithm was used to carry out a match between tracks.