### PR TITLE
Adding parent/children info for reco particles

### DIFF
--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -44,6 +44,9 @@ namespace caf
 
       RecoObjType origRecoObjType = RecoObjType::kUnknownRecoObj;  ///< Is this a track or a shower?
 
+      int parent = -1;                                ///< Index of parent SRRecoParticle in the same branch, defaults to -1 if no parent
+      std::vector<unsigned int> daughters;             ///< Indices of daughters SRRecoParticles in the same branch
+
       std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco particle and true particle
   };

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -99,7 +99,8 @@
    <version ClassVersion="10" checksum="684361603"/>
   </class>
 
-  <class name="caf::SRRecoParticle" ClassVersion="15">
+  <class name="caf::SRRecoParticle" ClassVersion="16">
+   <version ClassVersion="16" checksum="4230274279"/>
    <version ClassVersion="15" checksum="4130745478"/>
    <version ClassVersion="14" checksum="621972464"/>
    <version ClassVersion="13" checksum="2634132066"/>


### PR DESCRIPTION
Simply adds parent/daughters information in `SRRecoParticle` to keep track of the reco hierarchy building.
For now using a simple `int` for parent by setting it by default to `-1` for particles reconstructed as primary. Not sure whether this is fine or we should go with a more complex type of object.