### PR TITLE
don't assign NaN to an int type

### DIFF
--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -31,7 +31,7 @@ namespace caf
       // Track characteristics
       float qual = NaN;      ///< Reco-specific quality metric (in TMS, equivalent to "hits in track"/"total hits in event"
 
-      short int charge = NaN; ///< Reconstructed charge for the track, values are (-1, 0, 1) for negative/neutral/positive tracks
+      short int charge = std::numeric_limits<short int>::lowest(); ///< Reconstructed charge for the track, expected values are (-1, 0, 1) for negative/neutral/positive tracks
 
       float len_gcm2 = NaN;  ///< Track length in g/cm2
       float len_cm   = NaN;  ///< Track length in centimeter (actual physical distance)


### PR DESCRIPTION
We were accidentally assigning a floating-point `NaN` to an `int`, which overflows it.  But more importantly, `int` types don't have a `NaN` value anyway.  Use the smallest possible `short int` as a sentinel instead.