### PR TITLE
added SRShower-related fields + unique id to link SRTrack/SRShower to SRRecoParticle obj

### DIFF
--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -23,8 +23,6 @@ namespace caf
     public:
       static constexpr int kPdgHadronicBlob = 2000000002;   ///< Special PDG code used for a "hadronic blob" (usu. calorimetrically reconstructed), borrowed from GENIE
       
-      unsigned int uid = 0; ///< Unique identifier for the SRTrack/SRShower (if any) associated to this SRRecoParticle
-
       bool        primary  = false;                   ///< Is this reco particle a "primary" one (i.e. emanates directly from the reconstructed vertex)?
 
       int         pdg      = 0;                       ///< PDG code inferred for this particle.

--- a/duneanaobj/StandardRecord/SRShower.h
+++ b/duneanaobj/StandardRecord/SRShower.h
@@ -19,23 +19,19 @@ namespace caf
       // less typing further below
       static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
 
-      unsigned int uid = 0; ///< Unique identifier to associate this SRShower with its SRRecoParticle object
-
       SRVector3D start;      ///< Shower 3D start point [cm]
-      SRVector3D end;        ///< Shower 3D end point [cm]
-      SRVector3D direction;  ///< Shower direction [cm]
+      SRVector3D direction;  ///< Shower direction (unit vector).
 
-      double time     = NaN;  ///< Time of shower formation [ns]
+      double time = NaN;     ///< Time of shower formation [ns]
       
       float Evis = -999.;    ///< Visible energy in voxels corresponding to this shower
       
       float qual = NaN;      ///< Reco-specific quality metric (for istance trackScore value) 
 
-      float len_gcm2 = NaN;  ///< Shower length in g/cm2
-      float len_cm   = NaN;  ///< Shower length in centimeter (actual physical distance)
+      float len_cm   = NaN;  ///< Shower length [cm]. The definition is reco-dependent; consult the documentation of the specific reconstruction algorithm (e.g. Pandora, SPINE) for its exact meaning before use.
       
-      float dEdx; ///< dE/dx value at the shower start
-      float conversionGap; ///< Spatial distance between the photon creation and its conversion into e+e- pair [cm]
+      float initial_dEdx;    ///< dE/dx value at the shower start
+      float conversionGap;   ///< Spatial distance between the photon creation and its conversion into e+e- pair [cm]
 
       std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this shower and true particle

--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -19,8 +19,6 @@ namespace caf
       // less typing further below
       static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
 
-      unsigned int uid = 0; ///< Unique identifier to associate this SRTrack with its SRRecoParticle object
-
       SRVector3D start;      ///< Track 3D start point [cm]
       SRVector3D end;        ///< Track 3D end point [cm]
       SRVector3D dir;        ///< Unit vector representing estimate of track direction *taken from start point*


### PR DESCRIPTION
This PR adds data members to `SRRecoParticle`, `SRRecoShower` and `SRRecoTrack` as part of the process of updating the `PandoraRecoBranchFiller `in NDCAF. In particular:

- **SRShower**: I added the dE/dx and conversion gap values that we use at the CAF level to tell whether the particle is a photon or an electron. I've also added the length of the shower, trying to mirror the SRTrack attributes

- **SRShower** / **SRTrack** / **SRecoParticle** : I've tried to address the need of having a direct link between the track/shower obj and the more general reco particle. I added a unique id for both track and shower with the idea that it would encode the spill/slice/cluster info within it. If the SRRecoParticle has a track (shower) linked to it, then the trackUID (showerUID) would be the same as the track (shower) attribute `uid`