### PR TITLE
23 linkage between low level and high level reco objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ##### current
 
+##### [v04_00_00] -- 2026-06-22
+* Linkage between low-level and high-level reco objects [#81]
+
 ##### [v03_16_00] -- 2026-06-17
 * Add fields for ProtoDUNE use [#87]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ cmake_minimum_required (VERSION 3.20 FATAL_ERROR)
 # here will get overwritten by the project line with the same value when
 # we migrate to the NEW policy
 
-project(duneanaobj VERSION 03.14.00 LANGUAGES CXX)
-set(${PROJECT_NAME}_CMAKE_PROJECT_VERSION_STRING 03.14.00)
+project(duneanaobj VERSION 04.00.00 LANGUAGES CXX)
+set(${PROJECT_NAME}_CMAKE_PROJECT_VERSION_STRING 04.00.00)
 
 message(STATUS "\n\n  ==========================   ${PROJECT_NAME}   ==========================")
 

--- a/duneanaobj/StandardRecord/Navigate.cxx
+++ b/duneanaobj/StandardRecord/Navigate.cxx
@@ -11,4 +11,8 @@ namespace caf
   template const SRTrueParticle * FindParticle(const SRTruthBranch & truth, const TrueParticleID & id);
 
   template const SRTrueInteraction * FindInteraction(const SRTruthBranch & truth,  long int id);
+
+  const SRRecoParticle  * FindRecoParticle(const StandardRecord & sr, const SRRecoParticleID& id);
+
+  const SRRecoObjBase * FindRecoObjBase(const StandardRecord & sr, const SRRecoBaseID& id);
 }

--- a/duneanaobj/StandardRecord/Navigate.h
+++ b/duneanaobj/StandardRecord/Navigate.h
@@ -4,6 +4,8 @@
 #include <type_traits>
 
 #include "duneanaobj/StandardRecord/SRTruthBranch.h"
+#include "duneanaobj/StandardRecord/SRRecoObjBase.h"
+#include "duneanaobj/StandardRecord/StandardRecord.h"
 
 namespace caf
 {
@@ -30,5 +32,7 @@ namespace caf
   const typename std::conditional<std::is_same_v<TruthBranchType, SRTruthBranch>, 
                                   SRTrueInteraction, SRTrueInteractionProxy>::type * 
     FindInteraction(const TruthBranchType & truth,  long int id);
+
+  const SRRecoObjBase *FindRecoObjBase(const StandardRecord &sr, const SRRecoBaseID &id);
 }
 #endif //DUNEANAOBJ_NAVIGATE_H

--- a/duneanaobj/StandardRecord/Navigate.h
+++ b/duneanaobj/StandardRecord/Navigate.h
@@ -33,6 +33,8 @@ namespace caf
                                   SRTrueInteraction, SRTrueInteractionProxy>::type * 
     FindInteraction(const TruthBranchType & truth,  long int id);
 
+  const SRRecoParticle * FindRecoParticle(const StandardRecord & sr, const SRRecoParticleID& id);
+  
   const SRRecoObjBase *FindRecoObjBase(const StandardRecord &sr, const SRRecoBaseID &id);
 }
 #endif //DUNEANAOBJ_NAVIGATE_H

--- a/duneanaobj/StandardRecord/Navigate.ixx
+++ b/duneanaobj/StandardRecord/Navigate.ixx
@@ -31,4 +31,71 @@ namespace caf
     return &truth.nu[id];
   }
 
+  const SRRecoParticle * FindRecoParticle(const StandardRecord & sr, const SRRecoParticleID& id)
+  {
+    if (id.type == SRRecoParticleID::SRRecoParticleCollectionType::kUnknown || id.ixn < 0 || id.ipart < 0)
+      return nullptr;
+    if (id.type == SRRecoParticleID::SRRecoParticleCollectionType::kSPINE)
+      return &sr.common.ixn.dlp[id.ixn].part.dlp[id.ipart];
+    else if (id.type == SRRecoParticleID::SRRecoParticleCollectionType::kPandora)
+      return &sr.common.ixn.pandora[id.ixn].part.pandora[id.ipart];
+    else if (id.type == SRRecoParticleID::SRRecoParticleCollectionType::kPida)
+      throw std::domain_error("Not implemented: " + std::to_string(id.type));
+    else if (id.type == SRRecoParticleID::SRRecoParticleCollectionType::kSandreco)
+      return &sr.common.ixn.sandreco[id.ixn].part.sandreco[id.ipart];
+    else
+      throw std::domain_error("Unknown SRRecoParticleCollectionType: " + std::to_string(id.type));
+  }
+
+  const SRRecoObjBase * FindRecoObjBase(const StandardRecord & sr, const SRRecoBaseID& id)
+  {
+    if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kUnknown || id.ixn < 0 || id.irecoobj < 0)
+      return nullptr;
+    if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kFDHDPandoraTrack)
+      return &sr.fd.hd.pandora[id.ixn].tracks[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::KFDHDPandoraShower)
+      return &sr.fd.hd.pandora[id.ixn].showers[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::KFDHDPandoraPFP)
+      return &sr.fd.hd.pandora[id.ixn].pfps[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kFDVDPandoraTrack)
+      return &sr.fd.vd.pandora[id.ixn].tracks[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::KFDVDPandoraShower)
+      return &sr.fd.vd.pandora[id.ixn].showers[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::KFDVDPandoraPFP)
+      return &sr.fd.vd.pandora[id.ixn].pfps[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kFDPDHDPandoraTrack)
+      return &sr.fd.pd_hd.pandora[id.ixn].tracks[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::KFDPDHDPandoraShower)
+      return &sr.fd.pd_hd.pandora[id.ixn].showers[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::KFDPDHDPandoraPFP)
+      return &sr.fd.pd_hd.pandora[id.ixn].pfps[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kFDPDVDPandoraTrack)
+      return &sr.fd.pd_vd.pandora[id.ixn].tracks[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::KFDPDVDPandoraShower)
+      return &sr.fd.pd_vd.pandora[id.ixn].showers[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::KFDPDVDPandoraPFP)
+      return &sr.fd.pd_vd.pandora[id.ixn].pfps[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kNDLArDLPTrack)
+      return &sr.nd.lar.dlp[id.ixn].tracks[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kNDLArDLPShower)
+      return &sr.nd.lar.dlp[id.ixn].showers[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kNDLArPandoraTrack)
+      return &sr.nd.lar.pandora[id.ixn].tracks[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kNDLARPandoraShower)
+      return &sr.nd.lar.pandora[id.ixn].showers[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kTMSTrack)
+      return &sr.nd.tms.ixn[id.ixn].tracks[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDTrack)
+      return &sr.nd.sand.ixn[id.ixn].tracks[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDShower)
+      return &sr.nd.sand.ixn[id.ixn].showers[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDECalCluster)
+      return &sr.nd.sand.ixn[id.ixn].ECALClusters[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kGArTrack)
+      return &sr.nd.gar.ixn[id.ixn].tracks[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kGArEcalCluster)
+      return &sr.nd.gar.ixn[id.ixn].clusters[id.irecoobj];
+    else
+      throw std::domain_error("Unknown SRRecoBaseCollectionType: " + std::to_string(id.type));
+  }
 }

--- a/duneanaobj/StandardRecord/Navigate.ixx
+++ b/duneanaobj/StandardRecord/Navigate.ixx
@@ -33,7 +33,7 @@ namespace caf
 
   const SRRecoParticle * FindRecoParticle(const StandardRecord & sr, const SRRecoParticleID& id)
   {
-    if (id.type == SRRecoParticleID::SRRecoParticleCollectionType::kUnknown || id.ixn < 0 || id.ipart < 0)
+    if (!id)
       return nullptr;
     if (id.type == SRRecoParticleID::SRRecoParticleCollectionType::kSPINE)
       return &sr.common.ixn.dlp[id.ixn].part.dlp[id.ipart];
@@ -49,7 +49,7 @@ namespace caf
 
   const SRRecoObjBase * FindRecoObjBase(const StandardRecord & sr, const SRRecoBaseID& id)
   {
-    if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kUnknown || id.ixn < 0 || id.irecoobj < 0)
+    if (!id)
       return nullptr;
     if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kFDHDPandoraTrack)
       return &sr.fd.hd.pandora[id.ixn].tracks[id.irecoobj];

--- a/duneanaobj/StandardRecord/Navigate.ixx
+++ b/duneanaobj/StandardRecord/Navigate.ixx
@@ -85,12 +85,16 @@ namespace caf
       return &sr.nd.lar.pandora[id.ixn].showers[id.irecoobj];
     else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kTMSTrack)
       return &sr.nd.tms.ixn[id.ixn].tracks[id.irecoobj];
-    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDTrack)
-      return &sr.nd.sand.ixn[id.ixn].tracks[id.irecoobj];
-    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDShower)
-      return &sr.nd.sand.ixn[id.ixn].showers[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDGRAINTrack)
+      return &sr.nd.sand.ixn[id.ixn].grain.tracks[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDGRAINShower)
+      return &sr.nd.sand.ixn[id.ixn].grain.showers[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDTrackerTrack)
+      return &sr.nd.sand.ixn[id.ixn].tracker.tracks[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDTrackerShower)
+      return &sr.nd.sand.ixn[id.ixn].tracker.showers[id.irecoobj];
     else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDECalCluster)
-      return &sr.nd.sand.ixn[id.ixn].ECALClusters[id.irecoobj];
+      return &sr.nd.sand.ixn[id.ixn].ecal.clusters[id.irecoobj];
     else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kGArTrack)
       return &sr.nd.gar.ixn[id.ixn].tracks[id.irecoobj];
     else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kGArEcalCluster)

--- a/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
+++ b/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
@@ -24,6 +24,7 @@ namespace caf
   template class Proxy<TrueParticleID::PartType>;
   template class Proxy<RecoObjType>;
   template class Proxy<SRRecoParticleID::SRRecoParticleCollectionType>;
+  template class Proxy<SRRecoBaseID::SRRecoBaseCollectionType>;
 
   template const SRTrueParticleProxy * FindParticle(const SRTruthBranchProxy & truth, const TrueParticleIDProxy & id);
   template const SRTrueInteractionProxy * FindInteraction(const SRTruthBranchProxy & truth,  long int id);

--- a/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
+++ b/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
@@ -23,6 +23,7 @@ namespace caf
 
   template class Proxy<TrueParticleID::PartType>;
   template class Proxy<RecoObjType>;
+  template class Proxy<SRRecoParticleID::SRRecoParticleCollectionType>;
 
   template const SRTrueParticleProxy * FindParticle(const SRTruthBranchProxy & truth, const TrueParticleIDProxy & id);
   template const SRTrueInteractionProxy * FindInteraction(const SRTruthBranchProxy & truth,  long int id);

--- a/duneanaobj/StandardRecord/SRECALCluster.h
+++ b/duneanaobj/StandardRecord/SRECALCluster.h
@@ -9,7 +9,6 @@
 #define DUNEANAOBJ_SRECALCLUSTER_H
 
 #include "duneanaobj/StandardRecord/SRVector3D.h"
-#include "duneanaobj/StandardRecord/SRTrueParticle.h"
 #include "duneanaobj/StandardRecord/SRRecoObjBase.h"
 
 namespace caf

--- a/duneanaobj/StandardRecord/SRECALCluster.h
+++ b/duneanaobj/StandardRecord/SRECALCluster.h
@@ -10,10 +10,11 @@
 
 #include "duneanaobj/StandardRecord/SRVector3D.h"
 #include "duneanaobj/StandardRecord/SRTrueParticle.h"
+#include "duneanaobj/StandardRecord/SRRecoObjBase.h"
 
 namespace caf
 {
-  class SRECALCluster
+  class SRECALCluster : public SRRecoObjBase
   {
     public:
       int id; ///< Cluster id 

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -137,9 +137,9 @@ namespace caf
         kSandreco
       };
 
-    int ixn = -1;                                 ///< Index of SRInteraction in the SRInteractionBranch
-    SRRecoParticleCollectionType type = kUnknown; ///< Which of the SRRecoParticle collections in SRRecoParticlesBranch this particle lives in
-    int ipart = -1;                               ///< Index of SRRecoParticle in the specified SRRecoParticlesBranch collection of the SRInteraction
+    int ixn = -1;                                                               ///< Index of SRInteraction in the SRInteractionBranch
+    SRRecoParticleCollectionType type = SRRecoParticleCollectionType::kUnknown; ///< Which of the SRRecoParticle collections in SRRecoParticlesBranch this particle lives in
+    int ipart = -1;                                                             ///< Index of SRRecoParticle in the specified SRRecoParticlesBranch collection of the SRInteraction
   };
 
   /// \brief Identifies a reconstructed object by the interaction it belongs to,
@@ -152,8 +152,18 @@ namespace caf
       enum SRRecoBaseCollectionType {
           kUnknown,
           // FD
-          kFDPandoraTrack,
-          KFDPandoraShower,
+          kFDHDPandoraTrack,
+          KFDHDPandoraShower,
+          KFDHDPandoraPFP,
+          kFDVDPandoraTrack,
+          KFDVDPandoraShower,
+          KFDVDPandoraPFP,
+          kFDPDHDPandoraTrack,
+          KFDPDHDPandoraShower,
+          KFDPDHDPandoraPFP,
+          kFDPDVDPandoraTrack,
+          KFDPDVDPandoraShower,
+          KFDPDVDPandoraPFP,
           // NDLAr
           kNDLArDLPTrack,
           kNDLArDLPShower,
@@ -164,7 +174,10 @@ namespace caf
           // SAND
           kSANDTrack,
           kSANDShower,
-          kSANDECalCluster
+          kSANDECalCluster,
+          // GAr
+          kGArTrack,
+          kGArEcalCluster
       };
 
       int      ixn   = -1;                       ///< Index of SRInteraction in the SRInteractionBranch

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -140,6 +140,8 @@ namespace caf
     int ixn = -1;                                                               ///< Index of SRInteraction in the SRInteractionBranch
     SRRecoParticleCollectionType type = SRRecoParticleCollectionType::kUnknown; ///< Which of the SRRecoParticle collections in SRRecoParticlesBranch this particle lives in
     int ipart = -1;                                                             ///< Index of SRRecoParticle in the specified SRRecoParticlesBranch collection of the SRInteraction
+
+    inline bool operator bool() const { return !(type == SRRecoParticleCollectionType::kUnknown || ixn < 0 || ipart < 0); }; ///< Returns true if this is a valid ID (i.e. not default/invalid values)
   };
 
   /// \brief Identifies a reconstructed object by the interaction it belongs to,
@@ -148,7 +150,6 @@ namespace caf
   class SRRecoBaseID
   {
     public:
-    
       enum SRRecoBaseCollectionType {
           kUnknown,
           // FD
@@ -180,9 +181,11 @@ namespace caf
           kGArEcalCluster
       };
 
-      int      ixn   = -1;                                                 ///< Index of SRInteraction in the SRInteractionBranch
-      SRRecoBaseCollectionType type = SRRecoBaseCollectionType::kUnknown;  ///< Which of the low-level reco objects collections this object lives in
-      int      irecoobj = -1;                                              ///< Index of SRRecoObjBase in the specified reco objects collection of the SRInteraction 
+    int      ixn   = -1;                                                 ///< Index of SRInteraction in the SRInteractionBranch
+    SRRecoBaseCollectionType type = SRRecoBaseCollectionType::kUnknown;  ///< Which of the low-level reco objects collections this object lives in
+    int      irecoobj = -1;                                              ///< Index of SRRecoObjBase in the specified reco objects collection of the SRInteraction 
+
+    inline bool operator bool() const { return !(type == SRRecoBaseCollectionType::kUnknown || ixn < 0 || irecoobj < 0); }; ///< Returns true if this is a valid ID (i.e. not default/invalid values)
   };
 
   /// Which reconstruction toolkit was used to reconstruct this FD event?

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -141,7 +141,7 @@ namespace caf
     SRRecoParticleCollectionType type = SRRecoParticleCollectionType::kUnknown; ///< Which of the SRRecoParticle collections in SRRecoParticlesBranch this particle lives in
     int ipart = -1;                                                             ///< Index of SRRecoParticle in the specified SRRecoParticlesBranch collection of the SRInteraction
 
-    inline bool operator bool() const { return !(type == SRRecoParticleCollectionType::kUnknown || ixn < 0 || ipart < 0); }; ///< Returns true if this is a valid ID (i.e. not default/invalid values)
+    inline operator bool() const { return !(type == SRRecoParticleCollectionType::kUnknown || ixn < 0 || ipart < 0); }; ///< Returns true if this is a valid ID (i.e. not default/invalid values)
   };
 
   /// \brief Identifies a reconstructed object by the interaction it belongs to,
@@ -185,7 +185,7 @@ namespace caf
     SRRecoBaseCollectionType type = SRRecoBaseCollectionType::kUnknown;  ///< Which of the low-level reco objects collections this object lives in
     int      irecoobj = -1;                                              ///< Index of SRRecoObjBase in the specified reco objects collection of the SRInteraction 
 
-    inline bool operator bool() const { return !(type == SRRecoBaseCollectionType::kUnknown || ixn < 0 || irecoobj < 0); }; ///< Returns true if this is a valid ID (i.e. not default/invalid values)
+    inline operator bool() const { return !(type == SRRecoBaseCollectionType::kUnknown || ixn < 0 || irecoobj < 0); }; ///< Returns true if this is a valid ID (i.e. not default/invalid values)
   };
 
   /// Which reconstruction toolkit was used to reconstruct this FD event?

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -125,10 +125,10 @@ namespace caf
   /// \brief Identifies a reconstructed particle by the interaction it belongs to, 
   /// which collection of reconstructed particles it belongs to, and its index 
   /// within that collection.
-  class RecoParticleID
+  class SRRecoParticleID
   {
     public:
-      enum RecoParticleCollectionType
+      enum SRRecoParticleCollectionType
       {
         kUnknown,
         kSPINE,
@@ -137,9 +137,9 @@ namespace caf
         kSandreco
       };
 
-    int ixn = -1;                               ///< Index of SRInteraction in the SRInteractionBranch
-    RecoParticleCollectionType type = kUnknown; ///< Which of the SRRecoParticle collections in SRRecoParticlesBranch this particle lives in
-    int ipart = -1;                             ///< Index of SRRecoParticle in the specified SRRecoParticlesBranch collection of the SRInteraction
+    int ixn = -1;                                 ///< Index of SRInteraction in the SRInteractionBranch
+    SRRecoParticleCollectionType type = kUnknown; ///< Which of the SRRecoParticle collections in SRRecoParticlesBranch this particle lives in
+    int ipart = -1;                               ///< Index of SRRecoParticle in the specified SRRecoParticlesBranch collection of the SRInteraction
   };  
 
   /// Which reconstruction toolkit was used to reconstruct this FD event?

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -174,8 +174,10 @@ namespace caf
           // TMS
           kTMSTrack,
           // SAND
-          kSANDTrack,
-          kSANDShower,
+          kSANDGRAINTrack,
+          kSANDGRAINShower,
+          kSANDTrackerTrack,
+          kSANDTrackerShower,
           kSANDECalCluster,
           // GAr
           kGArTrack,

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -140,7 +140,37 @@ namespace caf
     int ixn = -1;                                 ///< Index of SRInteraction in the SRInteractionBranch
     SRRecoParticleCollectionType type = kUnknown; ///< Which of the SRRecoParticle collections in SRRecoParticlesBranch this particle lives in
     int ipart = -1;                               ///< Index of SRRecoParticle in the specified SRRecoParticlesBranch collection of the SRInteraction
-  };  
+  };
+
+  /// \brief Identifies a reconstructed object by the interaction it belongs to,
+  /// which collection of reconstructed objects it belongs to, and its index
+  /// within that collection.
+  class SRRecoBaseID
+  {
+    public:
+    
+      enum SRRecoBaseCollectionType {
+          kUnknown,
+          // FD
+          kFDPandoraTrack,
+          KFDPandoraShower,
+          // NDLAr
+          kNDLArDLPTrack,
+          kNDLArDLPShower,
+          kNDLArPandoraTrack,
+          kNDLARPandoraShower,
+          // TMS
+          kTMSTrack,
+          // SAND
+          kSANDTrack,
+          kSANDShower,
+          kSANDECalCluster
+      };
+
+      int      ixn   = -1;                       ///< Index of SRInteraction in the SRInteractionBranch
+      SRRecoBaseCollectionType type = kUnknown;  ///< Which of the low-level reco objects collections this object lives in
+      int      irecoobj = -1;                    ///< Index of SRRecoObjBase in the specified reco objects collection of the SRInteraction 
+  };
 
   /// Which reconstruction toolkit was used to reconstruct this FD event?
   enum FD_RECO_STACK

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -122,6 +122,26 @@ namespace caf
       float hypothesis_pe = NaN; ///< hypothesis pe from reconstruction for this interaction
   };
 
+  /// \brief Identifies a reconstructed particle by the interaction it belongs to, 
+  /// which collection of reconstructed particles it belongs to, and its index 
+  /// within that collection.
+  class RecoParticleID
+  {
+    public:
+      enum RecoParticleCollectionType
+      {
+        kUnknown,
+        kSPINE,
+        kPandora,
+        kPida,
+        kSandreco
+      };
+
+    int ixn = -1;                               ///< Index of SRInteraction in the SRInteractionBranch
+    RecoParticleCollectionType type = kUnknown; ///< Which of the SRRecoParticle collections in SRRecoParticlesBranch this particle lives in
+    int ipart = -1;                             ///< Index of SRRecoParticle in the specified SRRecoParticlesBranch collection of the SRInteraction
+  };  
+
   /// Which reconstruction toolkit was used to reconstruct this FD event?
   enum FD_RECO_STACK
   {

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -180,9 +180,9 @@ namespace caf
           kGArEcalCluster
       };
 
-      int      ixn   = -1;                       ///< Index of SRInteraction in the SRInteractionBranch
-      SRRecoBaseCollectionType type = kUnknown;  ///< Which of the low-level reco objects collections this object lives in
-      int      irecoobj = -1;                    ///< Index of SRRecoObjBase in the specified reco objects collection of the SRInteraction 
+      int      ixn   = -1;                                                 ///< Index of SRInteraction in the SRInteractionBranch
+      SRRecoBaseCollectionType type = SRRecoBaseCollectionType::kUnknown;  ///< Which of the low-level reco objects collections this object lives in
+      int      irecoobj = -1;                                              ///< Index of SRRecoObjBase in the specified reco objects collection of the SRInteraction 
   };
 
   /// Which reconstruction toolkit was used to reconstruct this FD event?

--- a/duneanaobj/StandardRecord/SRGArECAL.h
+++ b/duneanaobj/StandardRecord/SRGArECAL.h
@@ -9,7 +9,6 @@
 #define DUNEANAOBJ_SRGARECAL_H
 
 #include "duneanaobj/StandardRecord/SRVector3D.h"
-#include "duneanaobj/StandardRecord/SRTrueParticle.h"
 #include "duneanaobj/StandardRecord/SRRecoObjBase.h"
 
 namespace caf

--- a/duneanaobj/StandardRecord/SRGArECAL.h
+++ b/duneanaobj/StandardRecord/SRGArECAL.h
@@ -10,10 +10,11 @@
 
 #include "duneanaobj/StandardRecord/SRVector3D.h"
 #include "duneanaobj/StandardRecord/SRTrueParticle.h"
+#include "duneanaobj/StandardRecord/SRRecoObjBase.h"
 
 namespace caf
 {
-  class SRGArECAL
+  class SRGArECAL : public SRRecoObjBase
   {
     public:
       SRVector3D position;  ///< ECAL cluster 3D position

--- a/duneanaobj/StandardRecord/SRNDShowerAssn.h
+++ b/duneanaobj/StandardRecord/SRNDShowerAssn.h
@@ -4,6 +4,7 @@
 #ifndef DUNEANAOBJ_SRNDSHOWERASSN_H
 #define DUNEANAOBJ_SRNDSHOWERASSN_H
 
+#include "duneanaobj/StandardRecord/SRRecoObjBase.h"
 #include "duneanaobj/StandardRecord/SRShower.h"
 #include "duneanaobj/StandardRecord/SRNDLAr.h"
 #include "duneanaobj/StandardRecord/SRTMS.h"
@@ -11,7 +12,7 @@
 #include "duneanaobj/StandardRecord/SRGAr.h"
 namespace caf
 {
-  class SRNDShowerAssn
+  class SRNDShowerAssn : public SRRecoObjBase
   {
     public:
       // note: no TMS or GAr right now since we don't have anything to connect to ND-LAr,

--- a/duneanaobj/StandardRecord/SRNDTrackAssn.h
+++ b/duneanaobj/StandardRecord/SRNDTrackAssn.h
@@ -4,6 +4,8 @@
 #ifndef DUNEANAOBJ_SRNDTRACKASSN_H
 #define DUNEANAOBJ_SRNDTRACKASSN_H
 
+#include "duneanaobj/StandardRecord/SRRecoObjBase.h"
+
 #include "duneanaobj/StandardRecord/SRNDLAr.h"
 #include "duneanaobj/StandardRecord/SRTMS.h"
 #include "duneanaobj/StandardRecord/SRMINERvA.h"
@@ -11,7 +13,7 @@
 
 namespace caf
 {
-  class SRNDTrackAssn
+  class SRNDTrackAssn : public SRRecoObjBase
   {
     private:
       static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();

--- a/duneanaobj/StandardRecord/SRPFP.h
+++ b/duneanaobj/StandardRecord/SRPFP.h
@@ -9,7 +9,6 @@
 #define DUNEANAOBJ_SRPFP_H
 
 #include "duneanaobj/StandardRecord/SRVector3D.h"
-#include "duneanaobj/StandardRecord/SRTrueParticle.h"
 #include "duneanaobj/StandardRecord/SRRecoObjBase.h"
 
 namespace caf

--- a/duneanaobj/StandardRecord/SRPFP.h
+++ b/duneanaobj/StandardRecord/SRPFP.h
@@ -10,10 +10,11 @@
 
 #include "duneanaobj/StandardRecord/SRVector3D.h"
 #include "duneanaobj/StandardRecord/SRTrueParticle.h"
+#include "duneanaobj/StandardRecord/SRRecoObjBase.h"
 
 namespace caf
 {
-  class SRPFP
+  class SRPFP : public SRRecoObjBase
   {
     public:
       // less typing further below

--- a/duneanaobj/StandardRecord/SRRecoObjBase.h
+++ b/duneanaobj/StandardRecord/SRRecoObjBase.h
@@ -1,0 +1,22 @@
+////////////////////////////////////////////////////////////////////////
+/// \file    SRTrack.h
+/// \brief   Reconstructed track object
+/// \author  J. Wolcott <jwolcott@fnal.gov>
+/// \date    Apr. 2023
+////////////////////////////////////////////////////////////////////////
+#ifndef DUNEANAOBJ_SRRECOOBJBASE_H
+#define DUNEANAOBJ_SRRECOOBJBASE_H
+
+#include "duneanaobj/StandardRecord/SRTrueParticle.h"
+
+namespace caf
+{
+
+  /// Base class for reco objects (allows a base pointer to be stored in SRRecoParticle)
+  // Leave it empty because inherited members are easily overlooked in the derived classes
+  class SRRecoObjBase
+  {};
+
+} // caf
+
+#endif //DUNEANAOBJ_SRRECOOBJBASE_H

--- a/duneanaobj/StandardRecord/SRRecoObjBase.h
+++ b/duneanaobj/StandardRecord/SRRecoObjBase.h
@@ -8,6 +8,7 @@
 #define DUNEANAOBJ_SRRECOOBJBASE_H
 
 #include "duneanaobj/StandardRecord/SRTrueParticle.h"
+#include "duneanaobj/StandardRecord/SREnums.h"
 
 namespace caf
 {
@@ -17,7 +18,7 @@ namespace caf
   class SRRecoObjBase
   {
     public:
-      int dummy = 0; ///< Dummy member to prevent empty class issues
+      SRRecoParticleID part; // The particle this object is associated with
   };
 
 } // caf

--- a/duneanaobj/StandardRecord/SRRecoObjBase.h
+++ b/duneanaobj/StandardRecord/SRRecoObjBase.h
@@ -15,7 +15,10 @@ namespace caf
   /// Base class for reco objects (allows a base pointer to be stored in SRRecoParticle)
   // Leave it empty because inherited members are easily overlooked in the derived classes
   class SRRecoObjBase
-  {};
+  {
+    public:
+      int dummy = 0; ///< Dummy member to prevent empty class issues
+  };
 
 } // caf
 

--- a/duneanaobj/StandardRecord/SRRecoObjBase.h
+++ b/duneanaobj/StandardRecord/SRRecoObjBase.h
@@ -13,8 +13,7 @@
 namespace caf
 {
 
-  /// Base class for reco objects (allows a base pointer to be stored in SRRecoParticle)
-  // Leave it empty because inherited members are easily overlooked in the derived classes
+  /// Base class for reco objects (enables navigation between SRRecoParticle and the underlying object it was made from)
   class SRRecoObjBase
   {
     public:

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -13,6 +13,8 @@
 
 namespace caf
 {
+  class SRRecoObjBase;
+
   /// \brief Reconstructed particle candidate
   class SRRecoParticle
   {
@@ -40,6 +42,8 @@ namespace caf
       // todo: would we prefer some kind of "extents" thing so that we can make a decision about containment later?
       //       or should this be the responsibility of the reco module?  (what about stuff that crosses detector boundaries?...)
       bool        contained = false;
+
+      const SRRecoObjBase * base = nullptr;           ///< Base (detector-specific) reco object this SRRecoParticle was made from.
 
       TrueParticleID truth;                       ///< Associated SRTrueParticle, if relevant (use SRTruthBranch::Particle() with this ID to grab it)
   };

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -52,7 +52,7 @@ namespace caf
       std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco particle and true particle
       
-      // const SRRecoObjBase * base = nullptr;           ///< Base (detector-specific) reco object this SRRecoParticle was made from.
+      SRRecoBaseID recoobj;                           ///< Id of the reconstructed object this particle is built on
   };
 
 } // caf

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -52,7 +52,7 @@ namespace caf
       std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco particle and true particle
       
-      const SRRecoObjBase * base = nullptr;           ///< Base (detector-specific) reco object this SRRecoParticle was made from.
+      // const SRRecoObjBase * base = nullptr;           ///< Base (detector-specific) reco object this SRRecoParticle was made from.
   };
 
 } // caf

--- a/duneanaobj/StandardRecord/SRShower.h
+++ b/duneanaobj/StandardRecord/SRShower.h
@@ -8,19 +8,19 @@
 #ifndef DUNEANAOBJ_SRSHOWER_H
 #define DUNEANAOBJ_SRSHOWER_H
 
+#include "duneanaobj/StandardRecord/SRRecoObjBase.h"
 #include "duneanaobj/StandardRecord/SRVector3D.h"
-#include "duneanaobj/StandardRecord/SRTrueParticle.h"
 
 namespace caf
 {
-  class SRShower
+  class SRShower : public SRRecoObjBase
   {
     public:
       SRVector3D start;      ///< Shower 3D start point [cm]
       SRVector3D direction;  ///< Shower 3D end point [cm]
       float Evis = -999.;    ///< Visible energy in voxels corresponding to this shower
 
-      SRTrueParticle truth;  ///< Best-match GEANT truth particle for this track
+      SRTrueParticle truth;  ///< Best-match GEANT truth particle for this shower
   };
 
 }

--- a/duneanaobj/StandardRecord/SRTrack.h
+++ b/duneanaobj/StandardRecord/SRTrack.h
@@ -7,12 +7,12 @@
 #ifndef DUNEANAOBJ_SRTRACK_H
 #define DUNEANAOBJ_SRTRACK_H
 
+#include "duneanaobj/StandardRecord/SRRecoObjBase.h"
 #include "duneanaobj/StandardRecord/SRVector3D.h"
-#include "duneanaobj/StandardRecord/SRTrueParticle.h"
 
 namespace caf
 {
-  class SRTrack
+  class SRTrack : public SRRecoObjBase
   {
     public:
       // less typing further below

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -105,7 +105,8 @@
    <version ClassVersion="10" checksum="684361603"/>
   </class>
 
-  <class name="caf::SRRecoParticle" ClassVersion="16">
+  <class name="caf::SRRecoParticle" ClassVersion="17">
+   <version ClassVersion="17" checksum="3627482381"/>
    <version ClassVersion="16" checksum="4230274279"/>
    <version ClassVersion="15" checksum="4130745478"/>
    <version ClassVersion="14" checksum="621972464"/>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -242,7 +242,8 @@
    <version ClassVersion="10" checksum="3398719456"/>
   </class>
 
-  <class name="caf::SRNDTrackAssn" ClassVersion="16">
+  <class name="caf::SRNDTrackAssn" ClassVersion="17">
+   <version ClassVersion="17" checksum="2425424940"/>
    <version ClassVersion="16" checksum="1266506394"/>
    <version ClassVersion="15" checksum="2460195191"/>
    <version ClassVersion="14" checksum="2659631828"/>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -155,7 +155,8 @@
   <class name="std::vector<caf::SRShower>">
   </class>
 
-<class name="caf::SRECALCluster" ClassVersion="16">
+<class name="caf::SRECALCluster" ClassVersion="17">
+ <version ClassVersion="17" checksum="2003075550"/>
  <version ClassVersion="16" checksum="3312245962"/>
    <version ClassVersion="15" checksum="1197469375"/>
    <version ClassVersion="14" checksum="772507687"/>
@@ -186,7 +187,8 @@
    <version ClassVersion="10" checksum="3607270087"/>
    </class>
 
-  <class name="caf::SRPFP" ClassVersion="10">
+  <class name="caf::SRPFP" ClassVersion="11">
+   <version ClassVersion="11" checksum="3636199025"/>
    <version ClassVersion="10" checksum="3744464743"/>
   </class>
 
@@ -280,7 +282,8 @@
   <class name="std::vector<caf::SRGArTrack>">
   </class>
 
-  <class name="caf::SRGArECAL" ClassVersion="12">
+  <class name="caf::SRGArECAL" ClassVersion="13">
+   <version ClassVersion="13" checksum="594495245"/>
    <version ClassVersion="12" checksum="3509084697"/>
    <version ClassVersion="11" checksum="2202249478"/>
    <version ClassVersion="10" checksum="4277816864"/>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -122,7 +122,8 @@
 
   <!-- - - - - - - - Types used in det-specific situations - - - - -->
 
-  <class name="caf::SRTrack" ClassVersion="20">
+  <class name="caf::SRTrack" ClassVersion="21">
+   <version ClassVersion="21" checksum="3631361424"/>
    <version ClassVersion="20" checksum="2342285040"/>
    <version ClassVersion="19" checksum="3416692108"/>
    <version ClassVersion="18" checksum="2409174386"/>
@@ -139,7 +140,8 @@
   <class name="std::vector<caf::SRTrack>">
   </class>
 
-  <class name="caf::SRShower" ClassVersion="16">
+  <class name="caf::SRShower" ClassVersion="17">
+   <version ClassVersion="17" checksum="3141158752"/>
    <version ClassVersion="16" checksum="2739725490"/>
    <version ClassVersion="15" checksum="1197469375"/>
    <version ClassVersion="14" checksum="772507687"/>
@@ -222,12 +224,14 @@
    <version ClassVersion="10" checksum="764455914"/>
   </class>
 
-  <class name="caf::SRNDShowerAssn" ClassVersion="11">
+  <class name="caf::SRNDShowerAssn" ClassVersion="12">
+   <version ClassVersion="12" checksum="3759476703"/>
    <version ClassVersion="11" checksum="2148903847"/>
    <version ClassVersion="10" checksum="3398719456"/>
   </class>
 
-  <class name="caf::SRNDTrackAssn" ClassVersion="15">
+  <class name="caf::SRNDTrackAssn" ClassVersion="16">
+   <version ClassVersion="16" checksum="3457555277"/>
    <version ClassVersion="15" checksum="2460195191"/>
    <version ClassVersion="14" checksum="2659631828"/>
    <version ClassVersion="13" checksum="744508541"/>
@@ -261,7 +265,8 @@
    <version ClassVersion="10" checksum="1674759717"/>
   </class>
 
-    <class name="caf::SRGArTrack" ClassVersion="16">
+    <class name="caf::SRGArTrack" ClassVersion="17">
+     <version ClassVersion="17" checksum="3841055326"/>
      <version ClassVersion="16" checksum="1020294526"/>
      <version ClassVersion="15" checksum="4066948530"/>
    <version ClassVersion="14" checksum="2591374164"/>


### PR DESCRIPTION
## Summary

This implements the reconstructed particle–lower-level object linkage as described in the architecture sketch:  
https://github.com/DUNE/duneanaobj/wiki/Reco-Particle--%E2%80%90--Lower-object-architecture-sketch

## Changes

- Added two identifier classes:
  - `SRRecoParticleID` to identify a reconstructed particle
  - `SRRecoBaseID` to identify a reconstructed low-level object
- Introduced a common base class for reconstructed objects: `SRRecoObjBase`.  
  All reconstructed object classes will inherit from this base.
- Extended:
  - `SRRecoParticle` to hold an `SRRecoParticleID`
  - `SRRecoObjBase` to hold an `SRRecoBaseID`  
  This establishes a bidirectional link between reconstructed particles and low-level reconstructed objects.
- Added helper functions to retrieve:
  - `SRRecoParticle` instances from an `SRRecoParticleID`
  - `SRRecoObjBase` instances from an `SRRecoBaseID`
