### PR TITLE
New fields for PD compatibility

### DIFF
--- a/duneanaobj/StandardRecord/SRInteraction.h
+++ b/duneanaobj/StandardRecord/SRInteraction.h
@@ -41,7 +41,10 @@ namespace caf
       bool preselected = false; ///< Was this interaction preselected?  (Useful for workflows where CAFs are preprocessed / filtered in the process of making concatenated files)
 
       bool contained() const; ///< Convenience function to check if the interaction is contained in the detector by checking the contained flag of all reco particles
-  };
+
+      bool isBeamSlice = false; 
+      
+    };
 
 } // caf
 

--- a/duneanaobj/StandardRecord/SRInteraction.h
+++ b/duneanaobj/StandardRecord/SRInteraction.h
@@ -42,8 +42,12 @@ namespace caf
 
       bool contained() const; ///< Convenience function to check if the interaction is contained in the detector by checking the contained flag of all reco particles
 
-      bool isBeamSlice = false; 
-      
+      bool isFromTrigger = true;  ///< Did this interaction arise from the physics process that triggered this readout?
+                                  ///< e.g. for a neutrino beam trigger, this is true for beam-induced neutrino                                            
+                                  ///< interactions and false for cosmic overlays; for a ProtoDUNE test-beam trigger,                                    
+                                  ///< true for the beam particle interaction and false for cosmics in the readout window.                                 
+                                  ///< In the ND with significant pileup, multiple interactions in the same SR may be true.                              
+                                  ///< Defaults to true since in most contexts beam-induced interactions are the expected case.  
     };
 
 } // caf

--- a/duneanaobj/StandardRecord/SRInteractionBranch.h
+++ b/duneanaobj/StandardRecord/SRInteractionBranch.h
@@ -12,17 +12,55 @@
 
 namespace caf
 {
+  struct BeamInstrumentation
+  {
+    BeamInstrumentation(){std::cout << "Default constructor called for BeamInstrumentation" << std::endl;};  
+    BeamInstrumentation(double p, bool valid, int trigger, std::vector<double> tof, std::vector<int> pdg_candidates, std::vector<int> tof_chan, double x, double y, double z, double dirX, double dirY, double dirZ, int nFibersP1, int nFibersP2, int nFibersP3, int nTracks, int nMomenta, int C0, int C1, double C0_pressure, double C1_pressure)
+    : beam_inst_P(p), beam_inst_valid(valid), beam_inst_trigger(trigger), beam_inst_TOF(tof), beam_inst_PDG_candidates(pdg_candidates), beam_inst_TOF_Chan(tof_chan), beam_inst_X(x), beam_inst_Y(y), beam_inst_Z(z), beam_inst_dirX(dirX), beam_inst_dirY(dirY), beam_inst_dirZ(dirZ), beam_inst_nFibersP1(nFibersP1), beam_inst_nFibersP2(nFibersP2), beam_inst_nFibersP3(nFibersP3), beam_inst_nTracks(nTracks), beam_inst_nMomenta(nMomenta), beam_inst_C0(C0), beam_inst_C1(C1), beam_inst_C0_pressure(C0_pressure), beam_inst_C1_pressure(C1_pressure)
+    {std::cout << "Parameterized constructor called for BeamInstrumentation" << std::endl;};
+
+    double beam_inst_P{-1.0};
+    bool beam_inst_valid{false};
+    int beam_inst_trigger{-1};
+    std::vector<double> beam_inst_TOF{};
+    std::vector< int > beam_inst_PDG_candidates{}, beam_inst_TOF_Chan{};
+    double beam_inst_X{-1.0}, beam_inst_Y{-1.0}, beam_inst_Z{-1.0};
+    double beam_inst_dirX{-1.0}, beam_inst_dirY{-1.0}, beam_inst_dirZ{-1.0};
+    int beam_inst_nFibersP1{-1}, beam_inst_nFibersP2{-1}, beam_inst_nFibersP3{-1};
+    int beam_inst_nTracks{-1}, beam_inst_nMomenta{-1};
+    int beam_inst_C0{-1}, beam_inst_C1{-1};
+    double beam_inst_C0_pressure{-1.0}, beam_inst_C1_pressure{-1.0};
+
+  };
+
+
   class SRInteractionBranch
   {
     public:
+      // prepare object to host beam instrumentation information, to be filled by the user if available
+      // BeamInstrumentation beamInstrumentation;
+
       std::vector<SRInteraction> dlp;       ///< Interactions from Deep Learn Physics machine learning reconstruction
       std::size_t ndlp;
 
       std::vector<SRInteraction> pandora;   ///< Interactions from Pandora reconstruction
       std::size_t npandora;
+      int beamPandoraSliceIndex = -1; ///< Index of the slice identified as the beam slice by the reconstruction (if any)
 
       std::vector<SRInteraction> sandreco;   ///< Interactions from sadreco reconstruction
       std::size_t nsandreco;
+
+      double beam_inst_P{-1.0};
+      bool beam_inst_valid{false};
+      int beam_inst_trigger{-1};
+      std::vector<double> beam_inst_TOF{};
+      std::vector< int > beam_inst_PDG_candidates{}, beam_inst_TOF_Chan{};
+      double beam_inst_X{-1.0}, beam_inst_Y{-1.0}, beam_inst_Z{-1.0};
+      double beam_inst_dirX{-1.0}, beam_inst_dirY{-1.0}, beam_inst_dirZ{-1.0};
+      int beam_inst_nFibersP1{-1}, beam_inst_nFibersP2{-1}, beam_inst_nFibersP3{-1};
+      int beam_inst_nTracks{-1}, beam_inst_nMomenta{-1};
+      int beam_inst_C0{-1}, beam_inst_C1{-1};
+      double beam_inst_C0_pressure{-1.0}, beam_inst_C1_pressure{-1.0};
 
   };
 }

--- a/duneanaobj/StandardRecord/SRInteractionBranch.h
+++ b/duneanaobj/StandardRecord/SRInteractionBranch.h
@@ -49,19 +49,6 @@ namespace caf
 
       std::vector<SRInteraction> sandreco;   ///< Interactions from sadreco reconstruction
       std::size_t nsandreco;
-
-      double beam_inst_P{-1.0};
-      bool beam_inst_valid{false};
-      int beam_inst_trigger{-1};
-      std::vector<double> beam_inst_TOF{};
-      std::vector< int > beam_inst_PDG_candidates{}, beam_inst_TOF_Chan{};
-      double beam_inst_X{-1.0}, beam_inst_Y{-1.0}, beam_inst_Z{-1.0};
-      double beam_inst_dirX{-1.0}, beam_inst_dirY{-1.0}, beam_inst_dirZ{-1.0};
-      int beam_inst_nFibersP1{-1}, beam_inst_nFibersP2{-1}, beam_inst_nFibersP3{-1};
-      int beam_inst_nTracks{-1}, beam_inst_nMomenta{-1};
-      int beam_inst_C0{-1}, beam_inst_C1{-1};
-      double beam_inst_C0_pressure{-1.0}, beam_inst_C1_pressure{-1.0};
-
   };
 }
 

--- a/duneanaobj/StandardRecord/SRInteractionBranch.h
+++ b/duneanaobj/StandardRecord/SRInteractionBranch.h
@@ -12,33 +12,9 @@
 
 namespace caf
 {
-  struct BeamInstrumentation
-  {
-    BeamInstrumentation(){std::cout << "Default constructor called for BeamInstrumentation" << std::endl;};  
-    BeamInstrumentation(double p, bool valid, int trigger, std::vector<double> tof, std::vector<int> pdg_candidates, std::vector<int> tof_chan, double x, double y, double z, double dirX, double dirY, double dirZ, int nFibersP1, int nFibersP2, int nFibersP3, int nTracks, int nMomenta, int C0, int C1, double C0_pressure, double C1_pressure)
-    : beam_inst_P(p), beam_inst_valid(valid), beam_inst_trigger(trigger), beam_inst_TOF(tof), beam_inst_PDG_candidates(pdg_candidates), beam_inst_TOF_Chan(tof_chan), beam_inst_X(x), beam_inst_Y(y), beam_inst_Z(z), beam_inst_dirX(dirX), beam_inst_dirY(dirY), beam_inst_dirZ(dirZ), beam_inst_nFibersP1(nFibersP1), beam_inst_nFibersP2(nFibersP2), beam_inst_nFibersP3(nFibersP3), beam_inst_nTracks(nTracks), beam_inst_nMomenta(nMomenta), beam_inst_C0(C0), beam_inst_C1(C1), beam_inst_C0_pressure(C0_pressure), beam_inst_C1_pressure(C1_pressure)
-    {std::cout << "Parameterized constructor called for BeamInstrumentation" << std::endl;};
-
-    double beam_inst_P{-1.0};
-    bool beam_inst_valid{false};
-    int beam_inst_trigger{-1};
-    std::vector<double> beam_inst_TOF{};
-    std::vector< int > beam_inst_PDG_candidates{}, beam_inst_TOF_Chan{};
-    double beam_inst_X{-1.0}, beam_inst_Y{-1.0}, beam_inst_Z{-1.0};
-    double beam_inst_dirX{-1.0}, beam_inst_dirY{-1.0}, beam_inst_dirZ{-1.0};
-    int beam_inst_nFibersP1{-1}, beam_inst_nFibersP2{-1}, beam_inst_nFibersP3{-1};
-    int beam_inst_nTracks{-1}, beam_inst_nMomenta{-1};
-    int beam_inst_C0{-1}, beam_inst_C1{-1};
-    double beam_inst_C0_pressure{-1.0}, beam_inst_C1_pressure{-1.0};
-
-  };
-
-
   class SRInteractionBranch
   {
     public:
-      // prepare object to host beam instrumentation information, to be filled by the user if available
-      // BeamInstrumentation beamInstrumentation;
 
       std::vector<SRInteraction> dlp;       ///< Interactions from Deep Learn Physics machine learning reconstruction
       std::size_t ndlp;

--- a/duneanaobj/StandardRecord/SRInteractionBranch.h
+++ b/duneanaobj/StandardRecord/SRInteractionBranch.h
@@ -21,7 +21,6 @@ namespace caf
 
       std::vector<SRInteraction> pandora;   ///< Interactions from Pandora reconstruction
       std::size_t npandora;
-      int beamPandoraSliceIndex = -1; ///< Index of the slice identified as the beam slice by the reconstruction (if any)
 
       std::vector<SRInteraction> sandreco;   ///< Interactions from sadreco reconstruction
       std::size_t nsandreco;

--- a/duneanaobj/StandardRecord/SRPFP.h
+++ b/duneanaobj/StandardRecord/SRPFP.h
@@ -13,6 +13,40 @@
 
 namespace caf
 {
+  struct SRSTEMScore
+  {
+    SRSTEMScore(){};
+    SRSTEMScore(float tscore, float sscore, float escore, float mscore, bool weighted, int plane)
+    : track_score(tscore), shower_score(sscore), empty_score(escore), michel_score(mscore),
+      charge_weighted(weighted), plane_ID(plane) {};
+
+    float track_score{0};
+    float shower_score{0};
+    float empty_score{0};
+    float michel_score{0};
+    bool charge_weighted{false};
+    int plane_ID{-1};
+
+    public:
+      SRSTEMScore& operator/=(double scalar) {
+        track_score /= scalar;
+        shower_score /= scalar;
+        empty_score /= scalar;
+        michel_score /= scalar;
+        return *this; // Return a reference to the modified object
+      }
+
+      SRSTEMScore operator/(double scalar) {
+        track_score /= scalar;
+        shower_score /= scalar;
+        empty_score /= scalar;
+        michel_score /= scalar;
+        return SRSTEMScore(track_score, shower_score, empty_score, michel_score, charge_weighted, plane_ID); // Return a reference to the modified object
+      }
+  };
+
+
+
   class SRPFP
   {
     public:
@@ -50,6 +84,10 @@ namespace caf
 
       //Track/Shower BDT score
       float track_score = NaN;
+
+      // EM/Track/Michel ID Scores -- see https://doi.org/10.1140/epjc/s10052-022-10791-2
+      SRSTEMScore cnn_stem_scores;
+
   };
 
 }

--- a/duneanaobj/StandardRecord/SRPFP.h
+++ b/duneanaobj/StandardRecord/SRPFP.h
@@ -13,40 +13,6 @@
 
 namespace caf
 {
-  struct SRSTEMScore
-  {
-    SRSTEMScore(){};
-    SRSTEMScore(float tscore, float sscore, float escore, float mscore, bool weighted, int plane)
-    : track_score(tscore), shower_score(sscore), empty_score(escore), michel_score(mscore),
-      charge_weighted(weighted), plane_ID(plane) {};
-
-    float track_score{0};
-    float shower_score{0};
-    float empty_score{0};
-    float michel_score{0};
-    bool charge_weighted{false};
-    int plane_ID{-1};
-
-    public:
-      SRSTEMScore& operator/=(double scalar) {
-        track_score /= scalar;
-        shower_score /= scalar;
-        empty_score /= scalar;
-        michel_score /= scalar;
-        return *this; // Return a reference to the modified object
-      }
-
-      SRSTEMScore operator/(double scalar) {
-        track_score /= scalar;
-        shower_score /= scalar;
-        empty_score /= scalar;
-        michel_score /= scalar;
-        return SRSTEMScore(track_score, shower_score, empty_score, michel_score, charge_weighted, plane_ID); // Return a reference to the modified object
-      }
-  };
-
-
-
   class SRPFP
   {
     public:
@@ -84,9 +50,6 @@ namespace caf
 
       //Track/Shower BDT score
       float track_score = NaN;
-
-      // EM/Track/Michel ID Scores -- see https://doi.org/10.1140/epjc/s10052-022-10791-2
-      SRSTEMScore cnn_stem_scores;
 
   };
 

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -7,8 +7,6 @@
 #ifndef DUNEANAOBJ_SRRECOPARTICLE_H
 #define DUNEANAOBJ_SRRECOPARTICLE_H
 
-#include <tuple>
-
 #include "duneanaobj/StandardRecord/SREnums.h"
 #include "duneanaobj/StandardRecord/SRLorentzVector.h"
 #include "duneanaobj/StandardRecord/SRVector3D.h"

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -51,8 +51,7 @@ namespace caf
 
       std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco particle and true particle
-      int         truthMatchByHits = -1;     ///< Index of the best truth match by hits in the SRTruthBranch, or -1 if no match
-      std::tuple<int, int, int> truthMatchByHitsIndex = std::make_tuple(-1, -1, -1);      
+      int         truthMatchIndex = -1;     ///< Index of the best truth match by hits in truth and truthOverlap array, defaults to -1 if no match
 
   };
 

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -49,7 +49,6 @@ namespace caf
 
       std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco particle and true particle
-      int         truthMatchIndex = -1;     ///< Index of the best truth match by hits in truth and truthOverlap array, defaults to -1 if no match
 
   };
 

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -7,6 +7,8 @@
 #ifndef DUNEANAOBJ_SRRECOPARTICLE_H
 #define DUNEANAOBJ_SRRECOPARTICLE_H
 
+#include <tuple>
+
 #include "duneanaobj/StandardRecord/SREnums.h"
 #include "duneanaobj/StandardRecord/SRLorentzVector.h"
 #include "duneanaobj/StandardRecord/SRVector3D.h"
@@ -49,6 +51,9 @@ namespace caf
 
       std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco particle and true particle
+      int         truthMatchByHits = -1;     ///< Index of the best truth match by hits in the SRTruthBranch, or -1 if no match
+      std::tuple<int, int, int> truthMatchByHitsIndex = std::make_tuple(-1, -1, -1);      
+
   };
 
 } // caf

--- a/duneanaobj/StandardRecord/SRTrueParticle.h
+++ b/duneanaobj/StandardRecord/SRTrueParticle.h
@@ -7,6 +7,7 @@
 #define DUNEANAOBJ_SRTRUEPARTICLE_H
 
 #include <vector>
+#include <tuple>
 
 #include "duneanaobj/StandardRecord/SREnums.h"
 #include "duneanaobj/StandardRecord/SRLorentzVector.h"
@@ -27,6 +28,8 @@ namespace caf
     public:
       int       pdg             = 0;     ///< Particle
       int       G4ID            = -1;    ///< ID of the particle (taken from GEANT4 -- -1 if this particle is not propogated by G4)
+      std::tuple<int, int, int> thisIndex = std::make_tuple(-1, -1, -1); // will have size 3, with the indices for interaction, primary, and secondary arrays respectively.  Will be -1 if not applicable (e.g. for a primary particle, the secondary index will be -1)
+
       long int  interaction_id  = -1;    ///< True interaction ID (edep-sim 'vertexID' for ND, or GENIe record number for FD) of the source of this particle
       double     time            = NaN;   ///< Generation time at true interaction vertex [ns]
 
@@ -37,7 +40,9 @@ namespace caf
       SRVector3D      end_pos;          ///< Particle end position (decay, interaction, stop) [cm]
 
       int parent               = -1;       ///< GEANT4 trackID of parent particle from this particle
+      std::tuple<int, int, int> parentIndex = std::make_tuple(-1, -1, -1); // will have size 3, with the indices for interaction, primary, and secondary arrays respectively.  Will be -1 if not applicable (e.g. for a primary particle, the secondary index will be -1)
       std::vector<unsigned int> daughters; ///< GEANT4 trackIDs of daughter particles from this particle
+      std::vector<std::tuple<int, int, int>> daughterIndices; // will have size 3, with the indices for interaction, primary, and secondary arrays respectively.  Will be empty if not applicable (e.g. for a primary particle, the secondary index will be empty)
 
       /// @name GEANT4 process codes.
       ///   The "process" codes are defined here: https://geant4.kek.jp/Reference/11.1.1/G4ProcessType_8hh_source.html

--- a/duneanaobj/StandardRecord/SRTrueParticle.h
+++ b/duneanaobj/StandardRecord/SRTrueParticle.h
@@ -40,6 +40,9 @@ namespace caf
       int parent               = -1;       ///< GEANT4 trackID of parent particle from this particle
       std::vector<unsigned int> daughters; ///< GEANT4 trackIDs of daughter particles from this particle
 
+      TrueParticleID parentID;                   ///< SR index reference to parent particle (ixn + type + part index); unset if primary or not found
+      std::vector<TrueParticleID> daughtersID;   ///< SR index references to daughter particles
+
       /// @name GEANT4 process codes.
       ///   The "process" codes are defined here: https://geant4.kek.jp/Reference/11.1.1/G4ProcessType_8hh_source.html
       ///   The "subprocess" codes depend on the value of the "process" code (see previous).  The most relevant ones are:

--- a/duneanaobj/StandardRecord/SRTrueParticle.h
+++ b/duneanaobj/StandardRecord/SRTrueParticle.h
@@ -28,7 +28,6 @@ namespace caf
     public:
       int       pdg             = 0;     ///< Particle
       int       G4ID            = -1;    ///< ID of the particle (taken from GEANT4 -- -1 if this particle is not propogated by G4)
-      std::tuple<int, int, int> thisIndex = std::make_tuple(-1, -1, -1); // will have size 3, with the indices for interaction, primary, and secondary arrays respectively.  Will be -1 if not applicable (e.g. for a primary particle, the secondary index will be -1)
 
       long int  interaction_id  = -1;    ///< True interaction ID (edep-sim 'vertexID' for ND, or GENIe record number for FD) of the source of this particle
       double     time            = NaN;   ///< Generation time at true interaction vertex [ns]
@@ -40,9 +39,7 @@ namespace caf
       SRVector3D      end_pos;          ///< Particle end position (decay, interaction, stop) [cm]
 
       int parent               = -1;       ///< GEANT4 trackID of parent particle from this particle
-      std::tuple<int, int, int> parentIndex = std::make_tuple(-1, -1, -1); // will have size 3, with the indices for interaction, primary, and secondary arrays respectively.  Will be -1 if not applicable (e.g. for a primary particle, the secondary index will be -1)
       std::vector<unsigned int> daughters; ///< GEANT4 trackIDs of daughter particles from this particle
-      std::vector<std::tuple<int, int, int>> daughterIndices; // will have size 3, with the indices for interaction, primary, and secondary arrays respectively.  Will be empty if not applicable (e.g. for a primary particle, the secondary index will be empty)
 
       /// @name GEANT4 process codes.
       ///   The "process" codes are defined here: https://geant4.kek.jp/Reference/11.1.1/G4ProcessType_8hh_source.html

--- a/duneanaobj/StandardRecord/SRTrueParticle.h
+++ b/duneanaobj/StandardRecord/SRTrueParticle.h
@@ -7,7 +7,6 @@
 #define DUNEANAOBJ_SRTRUEPARTICLE_H
 
 #include <vector>
-#include <tuple>
 
 #include "duneanaobj/StandardRecord/SREnums.h"
 #include "duneanaobj/StandardRecord/SRLorentzVector.h"

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -65,22 +65,13 @@
    <version ClassVersion="10" checksum="2681983110"/>
   </class>
 
-  <class name="caf::SRInteractionBranch" ClassVersion="19">
-   <version ClassVersion="19" checksum="995432799"/>
-   <version ClassVersion="18" checksum="1572816117"/>
-   <version ClassVersion="17" checksum="2838705083"/>
-   <version ClassVersion="16" checksum="1999633423"/>
-   <version ClassVersion="15" checksum="4122733970"/>
-   <version ClassVersion="14" checksum="1999633423"/>
-   <version ClassVersion="13" checksum="5494552"/>
-   <version ClassVersion="12" checksum="995432799"/>
+  <class name="caf::SRInteractionBranch" ClassVersion="11">
    <version ClassVersion="11" checksum="3254538684"/>
    <version ClassVersion="10" checksum="1911225621"/>
   </class>
 
-  <class name="caf::SRInteraction" ClassVersion="14">
-   <version ClassVersion="14" checksum="2923159878"/>
-   <version ClassVersion="13" checksum="319519243"/>
+  <class name="caf::SRInteraction" ClassVersion="13">
+   <version ClassVersion="13" checksum="2923159878"/>
    <version ClassVersion="12" checksum="2000195876"/>
    <version ClassVersion="11" checksum="1154108588"/>
    <version ClassVersion="10" checksum="2468658506"/>
@@ -121,11 +112,7 @@
    <version ClassVersion="10" checksum="684361603"/>
   </class>
 
-  <class name="caf::SRRecoParticle" ClassVersion="20">
-   <version ClassVersion="20" checksum="4230274279"/>
-   <version ClassVersion="19" checksum="2513933526"/>
-   <version ClassVersion="18" checksum="1754766699"/>
-   <version ClassVersion="17" checksum="3246791971"/>
+  <class name="caf::SRRecoParticle" ClassVersion="16">
    <version ClassVersion="16" checksum="4230274279"/>
    <version ClassVersion="15" checksum="4130745478"/>
    <version ClassVersion="14" checksum="621972464"/>
@@ -203,9 +190,7 @@
    <version ClassVersion="10" checksum="3607270087"/>
    </class>
 
-  <class name="caf::SRPFP" ClassVersion="12">
-   <version ClassVersion="12" checksum="3744464743"/>
-   <version ClassVersion="11" checksum="126299658"/>
+  <class name="caf::SRPFP" ClassVersion="10">
    <version ClassVersion="10" checksum="3744464743"/>
   </class>
 
@@ -380,12 +365,8 @@
    <version ClassVersion="10" checksum="2662412328"/>
   </class>
 
-  <class name="caf::SRTrueParticle" ClassVersion="21">
-   <version ClassVersion="21" checksum="1858967982"/>
-   <version ClassVersion="20" checksum="399263066"/>
-   <version ClassVersion="19" checksum="3434896655"/>
-   <version ClassVersion="18" checksum="2703534434"/>
-   <version ClassVersion="17" checksum="2332556504"/>
+  <class name="caf::SRTrueParticle" ClassVersion="17">
+   <version ClassVersion="17" checksum="1858967982"/>
    <version ClassVersion="16" checksum="399263066"/>
    <version ClassVersion="15" checksum="1980366129"/>
    <version ClassVersion="14" checksum="1907525372"/>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -60,7 +60,8 @@
    <version ClassVersion="10" checksum="2681983110"/>
   </class>
 
-  <class name="caf::SRInteractionBranch" ClassVersion="18">
+  <class name="caf::SRInteractionBranch" ClassVersion="19">
+   <version ClassVersion="19" checksum="995432799"/>
    <version ClassVersion="18" checksum="1572816117"/>
    <version ClassVersion="17" checksum="2838705083"/>
    <version ClassVersion="16" checksum="1999633423"/>
@@ -113,7 +114,8 @@
    <version ClassVersion="10" checksum="684361603"/>
   </class>
 
-  <class name="caf::SRRecoParticle" ClassVersion="18">
+  <class name="caf::SRRecoParticle" ClassVersion="19">
+   <version ClassVersion="19" checksum="2513933526"/>
    <version ClassVersion="18" checksum="1754766699"/>
    <version ClassVersion="17" checksum="3246791971"/>
    <version ClassVersion="16" checksum="4230274279"/>
@@ -193,7 +195,8 @@
    <version ClassVersion="10" checksum="3607270087"/>
    </class>
 
-  <class name="caf::SRPFP" ClassVersion="11">
+  <class name="caf::SRPFP" ClassVersion="12">
+   <version ClassVersion="12" checksum="3744464743"/>
    <version ClassVersion="11" checksum="126299658"/>
    <version ClassVersion="10" checksum="3744464743"/>
   </class>
@@ -350,7 +353,8 @@
    <version ClassVersion="10" checksum="2662412328"/>
   </class>
 
-  <class name="caf::SRTrueParticle" ClassVersion="19">
+  <class name="caf::SRTrueParticle" ClassVersion="20">
+   <version ClassVersion="20" checksum="399263066"/>
    <version ClassVersion="19" checksum="3434896655"/>
    <version ClassVersion="18" checksum="2703534434"/>
    <version ClassVersion="17" checksum="2332556504"/>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -78,7 +78,8 @@
    <version ClassVersion="10" checksum="1911225621"/>
   </class>
 
-  <class name="caf::SRInteraction" ClassVersion="13">
+  <class name="caf::SRInteraction" ClassVersion="14">
+   <version ClassVersion="14" checksum="2923159878"/>
    <version ClassVersion="13" checksum="319519243"/>
    <version ClassVersion="12" checksum="2000195876"/>
    <version ClassVersion="11" checksum="1154108588"/>
@@ -120,7 +121,8 @@
    <version ClassVersion="10" checksum="684361603"/>
   </class>
 
-  <class name="caf::SRRecoParticle" ClassVersion="19">
+  <class name="caf::SRRecoParticle" ClassVersion="20">
+   <version ClassVersion="20" checksum="4230274279"/>
    <version ClassVersion="19" checksum="2513933526"/>
    <version ClassVersion="18" checksum="1754766699"/>
    <version ClassVersion="17" checksum="3246791971"/>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -380,7 +380,8 @@
    <version ClassVersion="10" checksum="2662412328"/>
   </class>
 
-  <class name="caf::SRTrueParticle" ClassVersion="20">
+  <class name="caf::SRTrueParticle" ClassVersion="21">
+   <version ClassVersion="21" checksum="1858967982"/>
    <version ClassVersion="20" checksum="399263066"/>
    <version ClassVersion="19" checksum="3434896655"/>
    <version ClassVersion="18" checksum="2703534434"/>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -60,12 +60,20 @@
    <version ClassVersion="10" checksum="2681983110"/>
   </class>
 
-  <class name="caf::SRInteractionBranch" ClassVersion="11">
+  <class name="caf::SRInteractionBranch" ClassVersion="18">
+   <version ClassVersion="18" checksum="1572816117"/>
+   <version ClassVersion="17" checksum="2838705083"/>
+   <version ClassVersion="16" checksum="1999633423"/>
+   <version ClassVersion="15" checksum="4122733970"/>
+   <version ClassVersion="14" checksum="1999633423"/>
+   <version ClassVersion="13" checksum="5494552"/>
+   <version ClassVersion="12" checksum="995432799"/>
    <version ClassVersion="11" checksum="3254538684"/>
    <version ClassVersion="10" checksum="1911225621"/>
   </class>
 
-  <class name="caf::SRInteraction" ClassVersion="12">
+  <class name="caf::SRInteraction" ClassVersion="13">
+   <version ClassVersion="13" checksum="319519243"/>
    <version ClassVersion="12" checksum="2000195876"/>
    <version ClassVersion="11" checksum="1154108588"/>
    <version ClassVersion="10" checksum="2468658506"/>
@@ -105,7 +113,9 @@
    <version ClassVersion="10" checksum="684361603"/>
   </class>
 
-  <class name="caf::SRRecoParticle" ClassVersion="16">
+  <class name="caf::SRRecoParticle" ClassVersion="18">
+   <version ClassVersion="18" checksum="1754766699"/>
+   <version ClassVersion="17" checksum="3246791971"/>
    <version ClassVersion="16" checksum="4230274279"/>
    <version ClassVersion="15" checksum="4130745478"/>
    <version ClassVersion="14" checksum="621972464"/>
@@ -183,7 +193,8 @@
    <version ClassVersion="10" checksum="3607270087"/>
    </class>
 
-  <class name="caf::SRPFP" ClassVersion="10">
+  <class name="caf::SRPFP" ClassVersion="11">
+   <version ClassVersion="11" checksum="126299658"/>
    <version ClassVersion="10" checksum="3744464743"/>
   </class>
 
@@ -339,7 +350,10 @@
    <version ClassVersion="10" checksum="2662412328"/>
   </class>
 
-  <class name="caf::SRTrueParticle" ClassVersion="16">
+  <class name="caf::SRTrueParticle" ClassVersion="19">
+   <version ClassVersion="19" checksum="3434896655"/>
+   <version ClassVersion="18" checksum="2703534434"/>
+   <version ClassVersion="17" checksum="2332556504"/>
    <version ClassVersion="16" checksum="399263066"/>
    <version ClassVersion="15" checksum="1980366129"/>
    <version ClassVersion="14" checksum="1907525372"/>


### PR DESCRIPTION
This pull request adds several new fields to the CAF (Common Analysis Format) data structures to enhance interaction, reconstruction, and truth-matching information. These changes improve the ability to identify and track beam slices, match reconstructed particles to true particles, and maintain compatibility with serialization via updated class versions.

The most important changes are:

**Interaction and Reconstruction Enhancements:**
* Added a new `isBeamSlice` boolean field to `SRInteraction` to indicate if an interaction is identified as the beam slice.
* Added a `beamPandoraSliceIndex` integer field to `SRInteractionBranch` to store the index of the slice identified as the beam slice by Pandora reconstruction.

**Truth Matching Improvements:**
* Added a `truthMatchIndex` field to `SRRecoParticle` to record the index of the best truth match by hits, defaulting to -1 if no match exists.

**Serialization and Versioning:**
* Updated class versions and checksums in `classes_def.xml` for all modified classes to ensure correct serialization and backward compatibility. [[1]](diffhunk://#diff-0581bc5996ff63864a642ddbc8b5093e17ebee2e80695404290f2af17e86d497L63-R77) [[2]](diffhunk://#diff-0581bc5996ff63864a642ddbc8b5093e17ebee2e80695404290f2af17e86d497L108-R120) [[3]](diffhunk://#diff-0581bc5996ff63864a642ddbc8b5093e17ebee2e80695404290f2af17e86d497L186-R200) [[4]](diffhunk://#diff-0581bc5996ff63864a642ddbc8b5093e17ebee2e80695404290f2af17e86d497L342-R360)