### PR TITLE
Adding fields for saving reweights

### DIFF
--- a/duneanaobj/StandardRecord/SRSystParamHeader.cxx
+++ b/duneanaobj/StandardRecord/SRSystParamHeader.cxx
@@ -3,7 +3,7 @@
 namespace caf
 {
   SRSystParamHeader::SRSystParamHeader()
-    : nshifts(0), id(-1)
+    : vals(0), id(-1)
   {
   }
 

--- a/duneanaobj/StandardRecord/SRSystParamHeader.cxx
+++ b/duneanaobj/StandardRecord/SRSystParamHeader.cxx
@@ -3,7 +3,7 @@
 namespace caf
 {
   SRSystParamHeader::SRSystParamHeader()
-    : vals(0), id(-1)
+    : id(-1)
   {
   }
 

--- a/duneanaobj/StandardRecord/SRSystParamHeader.h
+++ b/duneanaobj/StandardRecord/SRSystParamHeader.h
@@ -12,7 +12,7 @@ namespace caf
     SRSystParamHeader();
     ~SRSystParamHeader();
 
-    int nshifts;
+    std::vector<float> vals;
     std::string name;
     int id;
   };

--- a/duneanaobj/StandardRecord/SRTrueInteraction.h
+++ b/duneanaobj/StandardRecord/SRTrueInteraction.h
@@ -35,6 +35,12 @@
 namespace caf
 {
 
+   class SRDialWeights
+   {
+   public:
+     std::vector<float> weights;
+   };
+
    /// \brief True interaction of probe particle with detector.  Usually neutrinos, but occasionally cosmics etc.
    class SRTrueInteraction
    {
@@ -116,6 +122,8 @@ namespace caf
        std::vector<SRTrueParticle> sec;              ///< Secondary particles.  Note that not *all* secondaries are kept, only those used in the reco branches
 
        float                       xsec_cvwgt = NaN; ///<  Central value weight for cross section model
+
+       std::vector<SRDialWeights> syst_dials; ///< Reweights. Outer index = dial, inner index (SRDialWeights) = variation for that dial
 
    };
 

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -16,7 +16,8 @@
    <version ClassVersion="10" checksum="1612203321"/>
   </class>
 
-  <class name="caf::SRSystParamHeader" ClassVersion="10">
+  <class name="caf::SRSystParamHeader" ClassVersion="11">
+   <version ClassVersion="11" checksum="4008846007"/>
    <version ClassVersion="10" checksum="621537544"/>
   </class>
 
@@ -324,7 +325,8 @@
    <version ClassVersion="10" checksum="2608785459"/>
   </class>
 
-  <class name="caf::SRTrueInteraction" ClassVersion="17">
+  <class name="caf::SRTrueInteraction" ClassVersion="18">
+   <version ClassVersion="18" checksum="1807033241"/>
    <version ClassVersion="17" checksum="1565545093"/>
    <version ClassVersion="16" checksum="358248003"/>
    <version ClassVersion="15" checksum="880834593"/>
@@ -347,6 +349,9 @@
    <version ClassVersion="12" checksum="941873740"/>
    <version ClassVersion="11" checksum="4112437168"/>
     <version ClassVersion="10" checksum="3381095522"/>
+  </class>
+  <class name="caf::SRDialWeights" ClassVersion="10">
+   <version ClassVersion="10" checksum="2304707688"/>
   </class>
 
   <enum name="caf::Generator" ClassVersion="10" />


### PR DESCRIPTION
Adding fields to save reweights, having reweights from nusystematics in mind. Details presented in the [DUNE CM, May 2026](https://indico.fnal.gov/event/71671/timetable/?view=standard#78-cross-section-systematics-i).

Touches two files
1. SRSystParamHeader
   - Updating `int nshifts` to  `std::vector<float> vals` to save individual values of variations
   - **_This is a breaking change due to the drop of nshifts_**
   - Aware of the fact that we need extra info for multisim weights; TODO for the future
 2. SRTrueInteraction
    - New class, `SRDialWeights` added; this holds the reweights for a given parameter
    - SRTrueInteraction now have a vector of `SRDialWeights`

This will help us saving reweights to CAFs directly, through ndnusyst package (the updated branch for ndnusyst will follow soon)