### PR TITLE
Make the SKIP_CET path also generate a fully installable CMake package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,10 @@ if(NOT SKIP_CET)
 
 else()
     find_package(ROOT)
-    include_directories(.)
+    # Source root for the hand-written "duneanaobj/StandardRecord/*.h" includes,
+    # and the build root for the generated Proxy/Flat headers
+    # (SRProxy.h, FlatRecord.h, FwdDeclare.h), which land under ${PROJECT_BINARY_DIR}/duneanaobj/.
+    include_directories(. ${PROJECT_BINARY_DIR})
 endif()
 
 add_subdirectory(duneanaobj)

--- a/duneanaobj/StandardRecord/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/CMakeLists.txt
@@ -45,6 +45,8 @@ else()
     file( GLOB headers_files *.h )
     set_target_properties(StandardRecord PROPERTIES PUBLIC_HEADER "${headers_files}")
 
+    install( TARGETS StandardRecord EXPORT duneanaobjTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} PUBLIC_HEADER DESTINATION include/)
+#    install( FILES ${headers_files} DESTINATION "include/duneanaobj/StandardRecord" )
 
     install( TARGETS StandardRecord EXPORT duneanaobjTargets DESTINATION ${CMAKE_INSTALL_LIBDIR} )
     install( FILES ${headers_files} DESTINATION "include/duneanaobj/StandardRecord" )

--- a/duneanaobj/StandardRecord/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/CMakeLists.txt
@@ -27,6 +27,18 @@ else()
     include_directories($ENV{SRPROXY_INC})
 endif()
 
+# gen_srproxy drives castxml to parse the StandardRecord headers. castxml 0.6.x
+# (clang-based, emulating gcc) can't parse gcc-13's libstdc++/glibc as-is: it
+# represents the _FloatN types as non-convertible structs, which breaks <cmath>'s
+# __iseqsig overloads, and its clang trips over the __assume__ statement attribute
+# in <bits/stl_bvector.h>. Presenting as clang (-D__clang__=1) makes libstdc++
+# skip the __assume__ path, and remapping each _FloatN to a distinct convertible
+# builtin sidesteps the __iseqsig failures. None of these types appear in
+# StandardRecord, so this only affects how the system headers parse, not the
+# generated proxies. (Shared by both Proxy/ and Flat/ via inheritance.)
+# -Wno-macro-redefined silences the expected warnings from the _FloatN redefines.
+set(SRPROXY_CASTXML_CFLAGS "-D__clang__=1 -D_Float16=short -D_Float32=int -D_Float64=long -D_Float128=__int128 -D_Float32x=char -D_Float64x=wchar_t -D_Float128x=char16_t -fsized-deallocation -Wno-macro-redefined")
+
 # Proxy/ and Flat/ generate their sources with gen_srproxy, so only descend into
 # them when it was found.
 if(GEN_SRPROXY)

--- a/duneanaobj/StandardRecord/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/CMakeLists.txt
@@ -66,12 +66,14 @@ else()
             $<INSTALL_INTERFACE:include>
             ${ROOT_INCLUDE_DIRS}
     )
-    # Setup installation
+    # Setup installation. Install the headers under include/duneanaobj/StandardRecord/
+    # so the "duneanaobj/StandardRecord/..." include paths used throughout the
+    # sources resolve against the exported include/ interface. (PUBLIC_HEADER would
+    # flatten them straight into include/, which does not match those paths.)
     file( GLOB headers_files *.h )
-    set_target_properties(StandardRecord PROPERTIES PUBLIC_HEADER "${headers_files}")
 
-    install( TARGETS StandardRecord EXPORT duneanaobjTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} PUBLIC_HEADER DESTINATION include/)
-#    install( FILES ${headers_files} DESTINATION "include/duneanaobj/StandardRecord" )
+    install( TARGETS StandardRecord EXPORT duneanaobjTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install( FILES ${headers_files} DESTINATION include/duneanaobj/StandardRecord )
 
     # ROOT I/O dictionary. The CET path gets this from cet's build_dictionary;
     # here we drive rootcling directly via ROOT's root_generate_dictionary,

--- a/duneanaobj/StandardRecord/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/CMakeLists.txt
@@ -36,9 +36,15 @@ else()
     target_link_libraries( StandardRecord
                            ROOT::Core ROOT::Physics
                          )
-
+    target_include_directories(StandardRecord INTERFACE
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+            $<INSTALL_INTERFACE:include>
+            ${ROOT_INCLUDE_DIRS}
+    )
     # Setup installation
     file( GLOB headers_files *.h )
+    set_target_properties(StandardRecord PROPERTIES PUBLIC_HEADER "${headers_files}")
+
 
     install( TARGETS StandardRecord EXPORT duneanaobjTargets DESTINATION ${CMAKE_INSTALL_LIBDIR} )
     install( FILES ${headers_files} DESTINATION "include/duneanaobj/StandardRecord" )

--- a/duneanaobj/StandardRecord/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/CMakeLists.txt
@@ -8,8 +8,33 @@ FILE( GLOB src_files *.cxx )
 # For this directory only, pedantic option to catch uninitialized SR fields
 # add_compile_options(-Weffc++)
 
+# Locate the SRProxy code generator and runtime headers once, here, so both the
+# Proxy/ and Flat/ subdirectories share the result. Prefer a find_package()'able
+# SRProxy (which exports the SRProxy::SRProxy target carrying its headers), and
+# cascade back to the older $SRPROXY_INC / $SRPROXY_DIR layout otherwise.
+find_package(SRProxy QUIET CONFIG)
+if(SRProxy_FOUND)
+    message(STATUS "Found SRProxy CMake package at ${SRProxy_DIR}")
+    # SRProxy exports its headers but not the gen_srproxy executable,
+    # so look for it under the package's install prefix (then fall back to $SRPROXY_DIR/bin).
+    get_filename_component(SRPROXY_PREFIX "${SRProxy_DIR}/../../.." ABSOLUTE)
+    find_program(GEN_SRPROXY gen_srproxy HINTS "${SRPROXY_PREFIX}/bin" $ENV{SRPROXY_DIR}/bin)
+    get_target_property(SRPROXY_INCLUDE_DIRS SRProxy::SRProxy INTERFACE_INCLUDE_DIRECTORIES)
+    include_directories(${SRPROXY_INCLUDE_DIRS})
+else()
+    message(STATUS "SRProxy CMake package not found; using $SRPROXY_INC / $SRPROXY_DIR")
+    find_program(GEN_SRPROXY gen_srproxy HINTS $ENV{SRPROXY_DIR}/bin)
+    include_directories($ENV{SRPROXY_INC})
+endif()
+
+# Proxy/ and Flat/ generate their sources with gen_srproxy, so only descend into
+# them when it was found.
+if(GEN_SRPROXY)
     add_subdirectory(Proxy)
     add_subdirectory(Flat)
+else()
+    message(WARNING "Could not find gen_srproxy; skipping the Proxy and Flat subdirectories")
+endif()
 
 if(NOT SKIP_CET)
     cet_make_library( LIBRARY_NAME duneanaobj_StandardRecord

--- a/duneanaobj/StandardRecord/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/CMakeLists.txt
@@ -48,8 +48,39 @@ else()
     install( TARGETS StandardRecord EXPORT duneanaobjTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} PUBLIC_HEADER DESTINATION include/)
 #    install( FILES ${headers_files} DESTINATION "include/duneanaobj/StandardRecord" )
 
-    install( TARGETS StandardRecord EXPORT duneanaobjTargets DESTINATION ${CMAKE_INSTALL_LIBDIR} )
-    install( FILES ${headers_files} DESTINATION "include/duneanaobj/StandardRecord" )
+    # ROOT I/O dictionary. The CET path gets this from cet's build_dictionary;
+    # here we drive rootcling directly via ROOT's root_generate_dictionary,
+    # fed the same classes.h / classes_def.xml selection file. The result is a
+    # standalone StandardRecord_dict library (exported as
+    # duneanaobj::StandardRecord_dict) plus the .rootmap and _rdict.pcm that
+    # ROOT needs for autoloading at runtime.
+    root_generate_dictionary( G__StandardRecord
+                              ${CMAKE_CURRENT_SOURCE_DIR}/classes.h
+                              MODULE StandardRecord_dict
+                              LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/classes_def.xml
+                            )
+
+    add_library( StandardRecord_dict SHARED G__StandardRecord.cxx )
+    target_link_libraries( StandardRecord_dict
+                           PUBLIC StandardRecord ROOT::Core ROOT::Physics ROOT::TreePlayer
+                         )
+    target_include_directories( StandardRecord_dict INTERFACE
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+            $<INSTALL_INTERFACE:include>
+    )
+
+    install( TARGETS StandardRecord_dict
+             EXPORT duneanaobjTargets
+             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+           )
+
+    # rootcling emits these next to the build tree; ROOT looks for them beside
+    # the installed library, so install them into the same libdir.
+    install( FILES
+             "${CMAKE_CURRENT_BINARY_DIR}/libStandardRecord_dict_rdict.pcm"
+             "${CMAKE_CURRENT_BINARY_DIR}/libStandardRecord_dict.rootmap"
+             DESTINATION ${CMAKE_INSTALL_LIBDIR}
+           )
 
     # Setup CMake find_package related files
     install( EXPORT duneanaobjTargets

--- a/duneanaobj/StandardRecord/Config.cmake.in
+++ b/duneanaobj/StandardRecord/Config.cmake.in
@@ -6,4 +6,12 @@
 include ( CMakeFindDependencyMacro )
 find_dependency ( ROOT )
 
+# When duneanaobj was built against a find_package()'able SRProxy, the exported
+# Proxy/Flat targets link SRProxy::SRProxy, so consumers need it too. (Built
+# against the legacy $SRPROXY_INC layout, @SRProxy_FOUND@ is false and this is
+# skipped.)
+if ( @SRProxy_FOUND@ )
+    find_dependency ( SRProxy CONFIG )
+endif()
+
 include ( "${CMAKE_CURRENT_LIST_DIR}/duneanaobjTargets.cmake" )

--- a/duneanaobj/StandardRecord/Config.cmake.in
+++ b/duneanaobj/StandardRecord/Config.cmake.in
@@ -1,4 +1,9 @@
 
 @PACKAGE_INIT@
 
+# The exported targets carry ROOT imported targets (ROOT::Core, etc.) as
+# interface link libraries, so a consumer needs ROOT re-found here.
+include ( CMakeFindDependencyMacro )
+find_dependency ( ROOT )
+
 include ( "${CMAKE_CURRENT_LIST_DIR}/duneanaobjTargets.cmake" )

--- a/duneanaobj/StandardRecord/Flat/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Flat/CMakeLists.txt
@@ -1,20 +1,13 @@
 FILE(GLOB SR_DEPENDENCIES duneanaobj/StandardRecord/*.h)
 
-# Locate the SRProxy generator. Fall back to $SRPROXY_DIR/bin if it isn't on the PATH.
-find_program(GEN_SRPROXY gen_srproxy HINTS $ENV{SRPROXY_DIR}/bin)
-if(NOT GEN_SRPROXY)
-    message(WARNING "Could not find gen_srproxy; skipping FlatRecord generation and library build")
-    return()
-endif()
-
+# GEN_SRPROXY and the SRProxy include path are set up by the parent
+# StandardRecord/CMakeLists.txt, which only descends here when the generator
+# was found.
 add_custom_command(# Rebuild if anything in StandardRecord/ changes
                    DEPENDS ${SR_DEPENDENCIES}
                    OUTPUT FlatRecord.cxx FlatRecord.h FwdDeclare.h
                    COMMAND ${GEN_SRPROXY} --flat -i duneanaobj/StandardRecord/StandardRecord.h -o FlatRecord --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INCLUDE_PATH}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Flat/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --extra-cflags ' -D_Float16=short -fsized-deallocation'
   )
-
-
-include_directories($ENV{SRPROXY_INC})
 
 if(NOT SKIP_CET)
     message(STATUS "CETMODULES_CURRENT_PROJECT_NAME = '${CETMODULES_CURRENT_PROJECT_NAME}'")
@@ -40,6 +33,11 @@ else()
     add_library(duneanaobj_StandardRecordFlat
                 FlatRecord.cxx)
     target_link_libraries(duneanaobj_StandardRecordFlat ROOT::Core ROOT::Physics ROOT::TreePlayer)
+    if(SRProxy_FOUND)
+        # Propagate SRProxy to consumers of the exported target; duneanaobjConfig
+        # re-finds it via find_dependency(SRProxy).
+        target_link_libraries(duneanaobj_StandardRecordFlat SRProxy::SRProxy)
+    endif()
     target_include_directories(duneanaobj_StandardRecordFlat INTERFACE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
             $<INSTALL_INTERFACE:include>)

--- a/duneanaobj/StandardRecord/Flat/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Flat/CMakeLists.txt
@@ -33,9 +33,20 @@ if(NOT SKIP_CET)
     endif()
     install_headers(EXTRAS ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Flat/FlatRecord.h ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Flat/FwdDeclare.h)
 else()
+    # GNUInstallDirs is included by StandardRecord/CMakeLists.txt, but that runs
+    # after this subdirectory, so pull it in here for CMAKE_INSTALL_*DIR.
+    include(GNUInstallDirs)
+
     add_library(duneanaobj_StandardRecordFlat
                 FlatRecord.cxx)
     target_link_libraries(duneanaobj_StandardRecordFlat ROOT::Core ROOT::Physics ROOT::TreePlayer)
+    target_include_directories(duneanaobj_StandardRecordFlat INTERFACE
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+            $<INSTALL_INTERFACE:include>)
+
+    install(TARGETS duneanaobj_StandardRecordFlat
+            EXPORT duneanaobjTargets
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
     install(FILES ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Flat/FlatRecord.h ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Flat/FwdDeclare.h
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/duneanaobj)

--- a/duneanaobj/StandardRecord/Flat/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Flat/CMakeLists.txt
@@ -47,6 +47,6 @@ else()
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
     install(FILES ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Flat/FlatRecord.h ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Flat/FwdDeclare.h
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/duneanaobj)
+            DESTINATION include/duneanaobj/StandardRecord/Flat)
 
 endif()

--- a/duneanaobj/StandardRecord/Flat/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Flat/CMakeLists.txt
@@ -6,7 +6,7 @@ FILE(GLOB SR_DEPENDENCIES duneanaobj/StandardRecord/*.h)
 add_custom_command(# Rebuild if anything in StandardRecord/ changes
                    DEPENDS ${SR_DEPENDENCIES}
                    OUTPUT FlatRecord.cxx FlatRecord.h FwdDeclare.h
-                   COMMAND ${GEN_SRPROXY} --flat -i duneanaobj/StandardRecord/StandardRecord.h -o FlatRecord --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INCLUDE_PATH}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Flat/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --extra-cflags ' -D_Float16=short -fsized-deallocation'
+                   COMMAND ${GEN_SRPROXY} --flat -i duneanaobj/StandardRecord/StandardRecord.h -o FlatRecord --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INCLUDE_PATH}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Flat/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --extra-cflags "${SRPROXY_CASTXML_CFLAGS}"
   )
 
 if(NOT SKIP_CET)

--- a/duneanaobj/StandardRecord/Flat/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Flat/CMakeLists.txt
@@ -1,9 +1,16 @@
 FILE(GLOB SR_DEPENDENCIES duneanaobj/StandardRecord/*.h)
 
+# Locate the SRProxy generator. Fall back to $SRPROXY_DIR/bin if it isn't on the PATH.
+find_program(GEN_SRPROXY gen_srproxy HINTS $ENV{SRPROXY_DIR}/bin)
+if(NOT GEN_SRPROXY)
+    message(WARNING "Could not find gen_srproxy; skipping FlatRecord generation and library build")
+    return()
+endif()
+
 add_custom_command(# Rebuild if anything in StandardRecord/ changes
                    DEPENDS ${SR_DEPENDENCIES}
                    OUTPUT FlatRecord.cxx FlatRecord.h FwdDeclare.h
-                   COMMAND gen_srproxy --flat -i duneanaobj/StandardRecord/StandardRecord.h -o FlatRecord --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INCLUDE_PATH}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Flat/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --extra-cflags ' -D_Float16=short -fsized-deallocation'
+                   COMMAND ${GEN_SRPROXY} --flat -i duneanaobj/StandardRecord/StandardRecord.h -o FlatRecord --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INCLUDE_PATH}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Flat/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --extra-cflags ' -D_Float16=short -fsized-deallocation'
   )
 
 

--- a/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
@@ -49,6 +49,6 @@ else()
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
     install(FILES ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Proxy/SRProxy.h ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Proxy/FwdDeclare.h
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/duneanaobj)
+            DESTINATION include/duneanaobj/StandardRecord/Proxy)
 endif()
 

--- a/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
@@ -1,19 +1,13 @@
 FILE(GLOB SR_DEPENDENCIES duneanaobj/StandardRecord/*.h)
 
-# Locate the SRProxy generator. Fall back to $SRPROXY_DIR/bin if it isn't on the PATH.
-find_program(GEN_SRPROXY gen_srproxy HINTS $ENV{SRPROXY_DIR}/bin)
-if(NOT GEN_SRPROXY)
-    message(WARNING "Could not find gen_srproxy; skipping SRProxy generation and library build")
-    return()
-endif()
-
+# GEN_SRPROXY and the SRProxy include path are set up by the parent
+# StandardRecord/CMakeLists.txt, which only descends here when the generator
+# was found.
 add_custom_command(# Rebuild if anything in StandardRecord/ changes
                    DEPENDS ${SR_DEPENDENCIES}
                    OUTPUT SRProxy.cxx SRProxy.h FwdDeclare.h
                    COMMAND ${GEN_SRPROXY} -i duneanaobj/StandardRecord/StandardRecord.h -o SRProxy --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INCLUDE_PATH}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Proxy/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --epilog-fwd ${CMAKE_CURRENT_SOURCE_DIR}/EpilogFwd.h --extra-cflags ' -D_Float16=short -fsized-deallocation'
   )
-
-include_directories($ENV{SRPROXY_INC})
 
 # This is a very picky error buried inside template instantiations
 #add_definitions(-Wno-int-in-bool-context)
@@ -41,6 +35,11 @@ else()
     add_library(duneanaobj_StandardRecordProxy
                 SRProxy.cxx Instantiations.cxx)
     target_link_libraries(duneanaobj_StandardRecordProxy ROOT::Core ROOT::Physics ROOT::TreePlayer)
+    if(SRProxy_FOUND)
+        # Propagate SRProxy to consumers of the exported target; duneanaobjConfig
+        # re-finds it via find_dependency(SRProxy).
+        target_link_libraries(duneanaobj_StandardRecordProxy SRProxy::SRProxy)
+    endif()
     target_include_directories(duneanaobj_StandardRecordProxy INTERFACE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
             $<INSTALL_INTERFACE:include>)

--- a/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
@@ -34,9 +34,20 @@ if(NOT SKIP_CET)
     endif()
     install_headers(EXTRAS ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Proxy/SRProxy.h ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Proxy/FwdDeclare.h)
 else()
+    # GNUInstallDirs is included by StandardRecord/CMakeLists.txt, but that runs
+    # after this subdirectory, so pull it in here for CMAKE_INSTALL_*DIR.
+    include(GNUInstallDirs)
+
     add_library(duneanaobj_StandardRecordProxy
                 SRProxy.cxx Instantiations.cxx)
     target_link_libraries(duneanaobj_StandardRecordProxy ROOT::Core ROOT::Physics ROOT::TreePlayer)
+    target_include_directories(duneanaobj_StandardRecordProxy INTERFACE
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+            $<INSTALL_INTERFACE:include>)
+
+    install(TARGETS duneanaobj_StandardRecordProxy
+            EXPORT duneanaobjTargets
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
     install(FILES ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Proxy/SRProxy.h ${PROJECT_BINARY_DIR}/duneanaobj/StandardRecord/Proxy/FwdDeclare.h
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/duneanaobj)

--- a/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
@@ -6,7 +6,7 @@ FILE(GLOB SR_DEPENDENCIES duneanaobj/StandardRecord/*.h)
 add_custom_command(# Rebuild if anything in StandardRecord/ changes
                    DEPENDS ${SR_DEPENDENCIES}
                    OUTPUT SRProxy.cxx SRProxy.h FwdDeclare.h
-                   COMMAND ${GEN_SRPROXY} -i duneanaobj/StandardRecord/StandardRecord.h -o SRProxy --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INCLUDE_PATH}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Proxy/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --epilog-fwd ${CMAKE_CURRENT_SOURCE_DIR}/EpilogFwd.h --extra-cflags ' -D_Float16=short -fsized-deallocation'
+                   COMMAND ${GEN_SRPROXY} -i duneanaobj/StandardRecord/StandardRecord.h -o SRProxy --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INCLUDE_PATH}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Proxy/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --epilog-fwd ${CMAKE_CURRENT_SOURCE_DIR}/EpilogFwd.h --extra-cflags "${SRPROXY_CASTXML_CFLAGS}"
   )
 
 # This is a very picky error buried inside template instantiations

--- a/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/Proxy/CMakeLists.txt
@@ -1,9 +1,16 @@
 FILE(GLOB SR_DEPENDENCIES duneanaobj/StandardRecord/*.h)
 
+# Locate the SRProxy generator. Fall back to $SRPROXY_DIR/bin if it isn't on the PATH.
+find_program(GEN_SRPROXY gen_srproxy HINTS $ENV{SRPROXY_DIR}/bin)
+if(NOT GEN_SRPROXY)
+    message(WARNING "Could not find gen_srproxy; skipping SRProxy generation and library build")
+    return()
+endif()
+
 add_custom_command(# Rebuild if anything in StandardRecord/ changes
                    DEPENDS ${SR_DEPENDENCIES}
                    OUTPUT SRProxy.cxx SRProxy.h FwdDeclare.h
-                   COMMAND gen_srproxy -i duneanaobj/StandardRecord/StandardRecord.h -o SRProxy --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INCLUDE_PATH}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Proxy/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --epilog-fwd ${CMAKE_CURRENT_SOURCE_DIR}/EpilogFwd.h --extra-cflags ' -D_Float16=short -fsized-deallocation'
+                   COMMAND ${GEN_SRPROXY} -i duneanaobj/StandardRecord/StandardRecord.h -o SRProxy --target caf::StandardRecord --include-path ${PROJECT_SOURCE_DIR}:$ENV{ROOT_INCLUDE_PATH}:$ENV{ROOT_INC} --output-path duneanaobj/StandardRecord/Proxy/ --prolog ${CMAKE_CURRENT_SOURCE_DIR}/Prolog.h --epilog-fwd ${CMAKE_CURRENT_SOURCE_DIR}/EpilogFwd.h --extra-cflags ' -D_Float16=short -fsized-deallocation'
   )
 
 include_directories($ENV{SRPROXY_INC})


### PR DESCRIPTION
The SKIP_CET pathway is the only realistic way to build `duneanaobj` outside the warm embrace of the CET toolkit.
Unfortunately, until now, the CET version was also the only way to get a fully installable CMake-compatible package that could be used by another project via `find_package()`.
This PR rectifies that omission---now a user who isn't targeting UPS or FNAL-Spack can still generate a package that can be built and imported by CMake.