### PR TITLE
Create cross-subdetector reco object association for SAND

### DIFF
--- a/duneanaobj/StandardRecord/Navigate.ixx
+++ b/duneanaobj/StandardRecord/Navigate.ixx
@@ -95,6 +95,8 @@ namespace caf
       return &sr.nd.sand.ixn[id.ixn].tracker.showers[id.irecoobj];
     else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDECalCluster)
       return &sr.nd.sand.ixn[id.ixn].ecal.clusters[id.irecoobj];
+    else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kSANDAssn)
+      return &sr.nd.sand.ixn[id.ixn].trkmatch[id.irecoobj];
     else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kGArTrack)
       return &sr.nd.gar.ixn[id.ixn].tracks[id.irecoobj];
     else if (id.type == SRRecoBaseID::SRRecoBaseCollectionType::kGArEcalCluster)

--- a/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
+++ b/duneanaobj/StandardRecord/Proxy/Instantiations.cxx
@@ -25,6 +25,7 @@ namespace caf
   template class Proxy<RecoObjType>;
   template class Proxy<SRRecoParticleID::SRRecoParticleCollectionType>;
   template class Proxy<SRRecoBaseID::SRRecoBaseCollectionType>;
+  template class Proxy<SRSANDObjID::SubcollectionType>;
 
   template const SRTrueParticleProxy * FindParticle(const SRTruthBranchProxy & truth, const TrueParticleIDProxy & id);
   template const SRTrueInteractionProxy * FindInteraction(const SRTruthBranchProxy & truth,  long int id);

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -226,6 +226,15 @@ namespace caf
     kHitCollection  = 3,  ///< hit collection (mostly used to garbage collect all remaining hits)
   };
 
+  /// \brief Which of SAND's subdetectors does a reconstructed object hail from?
+  /// Used primarily to link them together in SRSANDAssn
+  enum SRSANDSubdetID
+  {
+    kUnknownSubDet = -1,
+    kGRAIN = 1,
+    kTracker = 2,
+    kECAL = 3,
+  };
 
 }
 

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -151,37 +151,41 @@ namespace caf
   class SRRecoBaseID
   {
     public:
+      /// \brief Which collection of low-level reco objects an object lives in.
+      /// NB: these values are serialized into CAFs, so they are written out explicitly.
+      /// A new entry takes the next unused number regardless of where it sits in this list:
+      /// keep it in the block it belongs to, and never renumber an existing one.
       enum SRRecoBaseCollectionType {
-          kUnknown,
+          kUnknown             = 0,
           // FD
-          kFDHDPandoraTrack,
-          KFDHDPandoraShower,
-          KFDHDPandoraPFP,
-          kFDVDPandoraTrack,
-          KFDVDPandoraShower,
-          KFDVDPandoraPFP,
-          kFDPDHDPandoraTrack,
-          KFDPDHDPandoraShower,
-          KFDPDHDPandoraPFP,
-          kFDPDVDPandoraTrack,
-          KFDPDVDPandoraShower,
-          KFDPDVDPandoraPFP,
+          kFDHDPandoraTrack    = 1,
+          KFDHDPandoraShower   = 2,
+          KFDHDPandoraPFP      = 3,
+          kFDVDPandoraTrack    = 4,
+          KFDVDPandoraShower   = 5,
+          KFDVDPandoraPFP      = 6,
+          kFDPDHDPandoraTrack  = 7,
+          KFDPDHDPandoraShower = 8,
+          KFDPDHDPandoraPFP    = 9,
+          kFDPDVDPandoraTrack  = 10,
+          KFDPDVDPandoraShower = 11,
+          KFDPDVDPandoraPFP    = 12,
           // NDLAr
-          kNDLArDLPTrack,
-          kNDLArDLPShower,
-          kNDLArPandoraTrack,
-          kNDLARPandoraShower,
+          kNDLArDLPTrack       = 13,
+          kNDLArDLPShower      = 14,
+          kNDLArPandoraTrack   = 15,
+          kNDLARPandoraShower  = 16,
           // TMS
-          kTMSTrack,
+          kTMSTrack            = 17,
           // SAND
-          kSANDGRAINTrack,
-          kSANDGRAINShower,
-          kSANDTrackerTrack,
-          kSANDTrackerShower,
-          kSANDECalCluster,
+          kSANDGRAINTrack      = 18,
+          kSANDGRAINShower     = 19,
+          kSANDTrackerTrack    = 20,
+          kSANDTrackerShower   = 21,
+          kSANDECalCluster     = 22,
           // GAr
-          kGArTrack,
-          kGArEcalCluster
+          kGArTrack            = 23,
+          kGArEcalCluster      = 24
       };
 
     int      ixn   = -1;                                                 ///< Index of SRInteraction in the SRInteractionBranch

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -183,6 +183,7 @@ namespace caf
           kSANDTrackerTrack    = 20,
           kSANDTrackerShower   = 21,
           kSANDECalCluster     = 22,
+          kSANDAssn            = 25,  ///< cross-subdetector association; see SRSANDAssn
           // GAr
           kGArTrack            = 23,
           kGArEcalCluster      = 24

--- a/duneanaobj/StandardRecord/SREnums.h
+++ b/duneanaobj/StandardRecord/SREnums.h
@@ -195,6 +195,36 @@ namespace caf
     inline operator bool() const { return !(type == SRRecoBaseCollectionType::kUnknown || ixn < 0 || irecoobj < 0); }; ///< Returns true if this is a valid ID (i.e. not default/invalid values)
   };
 
+  /// \brief Identifies one of SAND's subdetector reco objects 
+  /// by which collection within its SRSANDInt it lives in and its index within that collection.
+  /// Used primarily to link them together in SRSANDAssn.
+  ///
+  /// NB: there is deliberately no interaction index here.
+  /// SRSANDAssns live inside the SRSANDInt whose objects they associate,
+  /// so a constituent is always in the same interaction as the association that refers to it.
+  class SRSANDObjID
+  {
+    public:
+      /// \brief Which collection within an SRSANDInt an object lives in.
+      /// Note this names a *collection*, not a subdetector:
+      /// GRAIN and the tracker each store both tracks and showers,
+      /// so the subdetector alone would not be enough to say which container `idx` indexes into.
+      enum SubcollectionType
+      {
+        kUnknown       = -1,
+        kGRAINTrack    = 1,
+        kGRAINShower   = 2,
+        kTrackerTrack  = 3,
+        kTrackerShower = 4,
+        kECALCluster   = 5,
+      };
+
+      SubcollectionType type = kUnknown;  ///< Which collection within the SRSANDInt this object lives in
+      int               idx  = -1;        ///< Index of the object in the collection named by `type`
+
+      inline operator bool() const { return !(type == kUnknown || idx < 0); }; ///< Returns true if this is a valid ID (i.e. not default/invalid values)
+  };
+
   /// Which reconstruction toolkit was used to reconstruct this FD event?
   enum FD_RECO_STACK
   {
@@ -228,16 +258,6 @@ namespace caf
     kTrack          = 1,  ///< track
     kShower         = 2,  ///< shower
     kHitCollection  = 3,  ///< hit collection (mostly used to garbage collect all remaining hits)
-  };
-
-  /// \brief Which of SAND's subdetectors does a reconstructed object hail from?
-  /// Used primarily to link them together in SRSANDAssn
-  enum SRSANDSubdetID
-  {
-    kUnknownSubDet = -1,
-    kGRAIN = 1,
-    kTracker = 2,
-    kECAL = 3,
   };
 
 }

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -10,7 +10,6 @@
 #include "duneanaobj/StandardRecord/SREnums.h"
 #include "duneanaobj/StandardRecord/SRLorentzVector.h"
 #include "duneanaobj/StandardRecord/SRVector3D.h"
-#include <vector>
 
 namespace caf
 {
@@ -25,7 +24,7 @@ namespace caf
 
     public:
       static constexpr int kPdgHadronicBlob = 2000000002;   ///< Special PDG code used for a "hadronic blob" (usu. calorimetrically reconstructed), borrowed from GENIE
-
+      
       bool        primary  = false;                   ///< Is this reco particle a "primary" one (i.e. emanates directly from the reconstructed vertex)?
 
       int         pdg      = 0;                       ///< PDG code inferred for this particle.
@@ -33,7 +32,7 @@ namespace caf
 
       float       score    = NaN;                     ///< PID score for this particle, if relevant
 
-      float       E        = NaN;                     ///< Reconstructed energy for this particle [GeV] **n.b.: total energy including mass**
+      float       E        = NaN;                     ///< Reconstructed energy for this particle [GeV] **n.b.: total energy including mass** 
       PartEMethod E_method = PartEMethod::kUnknownMethod;   ///< Method used to determine energy for the particle
       SRVector3D  p;                                  ///< Reconstructed momentum for this particle
 
@@ -52,8 +51,8 @@ namespace caf
 
       std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco particle and true particle
-
-      std::vector<SRRecoBaseID> recoobj;                           ///< Id of the reconstructed object this particle is built on
+      
+      SRRecoBaseID recoobj;                           ///< Id of the reconstructed object this particle is built on
   };
 
 } // caf

--- a/duneanaobj/StandardRecord/SRRecoParticle.h
+++ b/duneanaobj/StandardRecord/SRRecoParticle.h
@@ -10,6 +10,7 @@
 #include "duneanaobj/StandardRecord/SREnums.h"
 #include "duneanaobj/StandardRecord/SRLorentzVector.h"
 #include "duneanaobj/StandardRecord/SRVector3D.h"
+#include <vector>
 
 namespace caf
 {
@@ -24,7 +25,7 @@ namespace caf
 
     public:
       static constexpr int kPdgHadronicBlob = 2000000002;   ///< Special PDG code used for a "hadronic blob" (usu. calorimetrically reconstructed), borrowed from GENIE
-      
+
       bool        primary  = false;                   ///< Is this reco particle a "primary" one (i.e. emanates directly from the reconstructed vertex)?
 
       int         pdg      = 0;                       ///< PDG code inferred for this particle.
@@ -32,7 +33,7 @@ namespace caf
 
       float       score    = NaN;                     ///< PID score for this particle, if relevant
 
-      float       E        = NaN;                     ///< Reconstructed energy for this particle [GeV] **n.b.: total energy including mass** 
+      float       E        = NaN;                     ///< Reconstructed energy for this particle [GeV] **n.b.: total energy including mass**
       PartEMethod E_method = PartEMethod::kUnknownMethod;   ///< Method used to determine energy for the particle
       SRVector3D  p;                                  ///< Reconstructed momentum for this particle
 
@@ -51,8 +52,8 @@ namespace caf
 
       std::vector<TrueParticleID> truth;              ///< Associated SRTrueParticle(s), if relevant (use SRTruthBranch::Particle() with these IDs to grab them)
       std::vector<float>   truthOverlap;              ///< Fractional overlap between this reco particle and true particle
-      
-      SRRecoBaseID recoobj;                           ///< Id of the reconstructed object this particle is built on
+
+      std::vector<SRRecoBaseID> recoobj;                           ///< Id of the reconstructed object this particle is built on
   };
 
 } // caf

--- a/duneanaobj/StandardRecord/SRSAND.h
+++ b/duneanaobj/StandardRecord/SRSAND.h
@@ -11,7 +11,8 @@
 #include "duneanaobj/StandardRecord/SRTrack.h"
 #include "duneanaobj/StandardRecord/SRShower.h"
 #include "duneanaobj/StandardRecord/SRECALCluster.h"
-#include "duneanaobj/StandardRecord/SREnums.h" 
+#include "duneanaobj/StandardRecord/SRSANDAssn.h"
+#include "duneanaobj/StandardRecord/SREnums.h"
 
 namespace caf
 {
@@ -60,6 +61,9 @@ namespace caf
         SRGRAIN grain;      ///< GRAIN reconstruction
         SRTracker tracker;  ///< Tracker reconstruction
         SREcal ecal;        ///< ECAL reconstruction
+
+        std::size_t ntrkmatch = 0;
+        std::vector<SRSANDAssn> trkmatch;  ///< Cross-subdetector associations among this interaction's objects
     };
 
     // ==================================================
@@ -69,8 +73,7 @@ namespace caf
     {
     public:
         std::size_t nixn = 0;
-        std::vector<SRSANDInt> ixn; ///< Reconstructed interactions
-
+        std::vector<SRSANDInt> ixn;  ///< Reconstructed interactions
     };
 
 } // namespace caf

--- a/duneanaobj/StandardRecord/SRSAND.h
+++ b/duneanaobj/StandardRecord/SRSAND.h
@@ -15,6 +15,14 @@
 
 namespace caf
 {
+    /// The information needed to uniquely identify a SAND subdetector o object
+    class SRSANDObjID
+    {
+        public:
+            SRSANDSubdetID subdet = kUnknownSubDet;
+            int            ixn    = -1;            ///< interaction ID
+            int            idx    = -1;            ///< index in container
+    };
 
     // ==================================================
     // GRAIN reconstruction

--- a/duneanaobj/StandardRecord/SRSAND.h
+++ b/duneanaobj/StandardRecord/SRSAND.h
@@ -15,15 +15,6 @@
 
 namespace caf
 {
-    /// The information needed to uniquely identify a SAND subdetector o object
-    class SRSANDObjID
-    {
-        public:
-            SRSANDSubdetID subdet = kUnknownSubDet;
-            int            ixn    = -1;            ///< interaction ID
-            int            idx    = -1;            ///< index in container
-    };
-
     // ==================================================
     // GRAIN reconstruction
     // ==================================================
@@ -77,13 +68,6 @@ namespace caf
     class SRSAND
     {
     public:
-        /// Unique identifier for each interaction
-        struct ID
-        {
-            int ixn = -1;  ///< interaction ID
-            int idx = -1;  ///< index in container
-        };
-
         std::size_t nixn = 0;
         std::vector<SRSANDInt> ixn; ///< Reconstructed interactions
 

--- a/duneanaobj/StandardRecord/SRSANDAssn.h
+++ b/duneanaobj/StandardRecord/SRSANDAssn.h
@@ -1,27 +1,35 @@
 /// \author  J. Wolcott <jwolcott@fnal.gov> & S. Lanzi <samuele.lanzi@cnaf.infn.it>
 /// \date    Aug. 2026
 
-#ifndef DUNEANAOBJ_SRNDTRACKASSN_H
-#define DUNEANAOBJ_SRNDTRACKASSN_H
+#ifndef DUNEANAOBJ_SRSANDASSN_H
+#define DUNEANAOBJ_SRSANDASSN_H
 
-#include "duneanaobj/StandardRecord/SRRecoObjBase.h"
-#include "duneanaobj/StandardRecord/SRSAND.h"
+#include <vector>
+
 #include "duneanaobj/StandardRecord/SREnums.h"
+#include "duneanaobj/StandardRecord/SRRecoObjBase.h"
+#include "duneanaobj/StandardRecord/SRTrack.h"
 
 namespace caf
 {
+  /// \brief A group of SAND subdetector reco objects reconstructed to go together
+  ///
+  /// Lives inside the SRSANDInt whose objects it associates,
+  /// so all of its constituents belong to that same SAND reco interaction.
   class SRSANDAssn : public SRRecoObjBase
   {
-    private:
-      static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
-
     public:
-      // idea: we want a sequence of subdetector elements.
-      // fill them in the order of reconstructed direction...
+      /// \brief The subdetector objects making up this association.
+      /// Filled in beginning-to-end order, i.e. following the reconstructed direction.
       std::vector<SRSANDObjID> constituents;
 
-      SRTrack trk;                   ///< new track object generated from synthesis of matched parts
+      /// \brief New track object generated from synthesis of the matched constituents.
+      ///
+      /// Its `start` --> the start point of the first constituent, and its `end` --> the endpoint of the last one.
+      /// `len_gcm2` includes range in any dead material between them.
+      /// `end` is left at its default (NaN) when the last constituent has no endpoint to derive one from, e.g. an SRECALCluster.
+      SRTrack trk;
   };
 }
 
-#endif //DUNEANAOBJ_SRNDTRACKASSN_H
+#endif //DUNEANAOBJ_SRSANDASSN_H

--- a/duneanaobj/StandardRecord/SRSANDAssn.h
+++ b/duneanaobj/StandardRecord/SRSANDAssn.h
@@ -1,0 +1,27 @@
+/// \author  J. Wolcott <jwolcott@fnal.gov> & S. Lanzi <samuele.lanzi@cnaf.infn.it>
+/// \date    Aug. 2026
+
+#ifndef DUNEANAOBJ_SRNDTRACKASSN_H
+#define DUNEANAOBJ_SRNDTRACKASSN_H
+
+#include "duneanaobj/StandardRecord/SRRecoObjBase.h"
+#include "duneanaobj/StandardRecord/SRSAND.h"
+#include "duneanaobj/StandardRecord/SREnums.h"
+
+namespace caf
+{
+  class SRSANDAssn : public SRRecoObjBase
+  {
+    private:
+      static constexpr float NaN = std::numeric_limits<float>::signaling_NaN();
+
+    public:
+      // idea: we want a sequence of subdetector elements.
+      // fill them in the order of reconstructed direction...
+      std::vector<SRSANDObjID> constituents;
+
+      SRTrack trk;                   ///< new track object generated from synthesis of matched parts
+  };
+}
+
+#endif //DUNEANAOBJ_SRNDTRACKASSN_H

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -354,22 +354,31 @@
    <version ClassVersion="10" checksum="1443507594"/>
   </class>
 
-<class name="caf::SRSANDInt" ClassVersion="24">
- <version ClassVersion="24" checksum="858502929"/>
- <version ClassVersion="23" checksum="3190481744"/>
- <version ClassVersion="22" checksum="858502929"/>
- <version ClassVersion="21" checksum="2703820925"/>
- <version ClassVersion="20" checksum="858502929"/>
- <version ClassVersion="19" checksum="294321243"/>
- <version ClassVersion="18" checksum="858502929"/>
- <version ClassVersion="17" checksum="294321243"/>
- <version ClassVersion="16" checksum="256951120"/>
- <version ClassVersion="15" checksum="1933940020"/>
- <version ClassVersion="14" checksum="3038143830"/>
- <version ClassVersion="13" checksum="1933940020"/>
- <version ClassVersion="12" checksum="3038143830"/>
- <version ClassVersion="11" checksum="515563825"/>
-   <version ClassVersion="10" checksum="87138233"/>
+  <class name="caf::SRSANDInt" ClassVersion="25">
+    <version ClassVersion="25" checksum="4079714457"/>
+    <version ClassVersion="24" checksum="858502929"/>
+    <version ClassVersion="23" checksum="3190481744"/>
+    <version ClassVersion="22" checksum="858502929"/>
+    <version ClassVersion="21" checksum="2703820925"/>
+    <version ClassVersion="20" checksum="858502929"/>
+    <version ClassVersion="19" checksum="294321243"/>
+    <version ClassVersion="18" checksum="858502929"/>
+    <version ClassVersion="17" checksum="294321243"/>
+    <version ClassVersion="16" checksum="256951120"/>
+    <version ClassVersion="15" checksum="1933940020"/>
+    <version ClassVersion="14" checksum="3038143830"/>
+    <version ClassVersion="13" checksum="1933940020"/>
+    <version ClassVersion="12" checksum="3038143830"/>
+    <version ClassVersion="11" checksum="515563825"/>
+    <version ClassVersion="10" checksum="87138233"/>
+  </class>
+
+  <class name="caf::SRSANDObjID" ClassVersion="10">
+    <version ClassVersion="10" checksum="3175599067"/>
+  </class>
+
+  <class name="caf::SRSANDAssn" ClassVersion="10">
+   <version ClassVersion="10" checksum="171733692"/>
   </class>
 
   <class name="caf::SRMINERvA"  ClassVersion="10">


### PR DESCRIPTION
As is already the case for TrueParticleID, recoobj could be made a `std::vector<SRRecoBaseID>` ([ref](https://github.com/DUNE/duneanaobj/blob/862d640bfcb3c6da0ec899691601b2f0fc9fe6c0/duneanaobj/StandardRecord/SRRecoParticle.h#L55)). This would allow:
- composite detectors such as SAND to associate track segments from different subdetectors with a single SRRecoParticle. In SAND, in fact, a single particle produces at least two distinct `SRRecoObjBase` objects;
- the subdetector-level association enabled by this change in SAND to be extended to the other near detector components as well, making combined analyses possible.