### PR TITLE
Adds missing classes to rootcling selection xml

### DIFF
--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -59,8 +59,12 @@
 
   <!-- - - - - - - - - Common reco - - - - - - - - - - - - - - - - -->
 
-  <class name="caf::SRRecoObjBase" ClassVersion="10" />
-  <class name="caf::SRRecoBaseID" ClassVersion="10" />
+  <class name="caf::SRRecoObjBase" ClassVersion="10" >
+    <version ClassVersion="10" checksum="1269770226"/>
+  </class>
+  <class name="caf::SRRecoBaseID" ClassVersion="10" >
+    <version ClassVersion="10" checksum="1023895248"/>
+  </class>
 
   <class name="caf::SRCommonRecoBranch" ClassVersion="12">
    <version ClassVersion="12" checksum="2257468413"/>
@@ -131,7 +135,9 @@
 
   <enum name="caf::PartEMethod" ClassVersion="10" />
 
-  <class name="caf::SRRecoParticleID" ClassVersion="10" />
+  <class name="caf::SRRecoParticleID" ClassVersion="10">
+    <version ClassVersion="10" checksum="171091538"/>
+  </class>
 
   <!-- - - - - - - - Types used in det-specific situations - - - - -->
 
@@ -153,7 +159,9 @@
   <class name="std::vector<caf::SRTrack>">
   </class>
 
-  <class name="caf::SRTracker" ClassVersion="10" />
+  <class name="caf::SRTracker" ClassVersion="10">
+    <version ClassVersion="10" checksum="3408431684"/>
+  </class>
 
   <class name="caf::SRShower" ClassVersion="17">
    <version ClassVersion="17" checksum="3141158752"/>
@@ -169,7 +177,9 @@
   <class name="std::vector<caf::SRShower>">
   </class>
 
-  <class name="caf::SREcal" ClassVersion="10" />
+  <class name="caf::SREcal" ClassVersion="10">
+    <version ClassVersion="10" checksum="1731417340"/>
+  </class>
 
   <class name="caf::SRECALCluster" ClassVersion="17">
    <version ClassVersion="17" checksum="2003075550"/>
@@ -185,7 +195,9 @@
   <class name="std::vector<caf::SRECALCluster>">
   </class>
 
-  <class name="caf::SRGRAIN" ClassVersion="10" />
+  <class name="caf::SRGRAIN" ClassVersion="10">
+    <version ClassVersion="10" checksum="295884993"/>
+  </class>
 
   <!-- - - - - - - - - - FD specific - - - - - - - - - - - - - - - -->
 

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -141,7 +141,8 @@
 
   <!-- - - - - - - - Types used in det-specific situations - - - - -->
 
-  <class name="caf::SRTrack" ClassVersion="21">
+  <class name="caf::SRTrack" ClassVersion="22">
+   <version ClassVersion="22" checksum="3226080584"/>
    <version ClassVersion="21" checksum="3631361424"/>
    <version ClassVersion="20" checksum="2342285040"/>
    <version ClassVersion="19" checksum="3416692108"/>
@@ -163,7 +164,8 @@
     <version ClassVersion="10" checksum="3408431684"/>
   </class>
 
-  <class name="caf::SRShower" ClassVersion="17">
+  <class name="caf::SRShower" ClassVersion="18">
+   <version ClassVersion="18" checksum="3219418264"/>
    <version ClassVersion="17" checksum="3141158752"/>
    <version ClassVersion="16" checksum="2739725490"/>
    <version ClassVersion="15" checksum="1197469375"/>
@@ -181,7 +183,8 @@
     <version ClassVersion="10" checksum="1731417340"/>
   </class>
 
-  <class name="caf::SRECALCluster" ClassVersion="17">
+  <class name="caf::SRECALCluster" ClassVersion="18">
+   <version ClassVersion="18" checksum="67658262"/>
    <version ClassVersion="17" checksum="2003075550"/>
    <version ClassVersion="16" checksum="3312245962"/>
    <version ClassVersion="15" checksum="1197469375"/>
@@ -216,7 +219,8 @@
    <version ClassVersion="10" checksum="3607270087"/>
    </class>
 
-  <class name="caf::SRPFP" ClassVersion="11">
+  <class name="caf::SRPFP" ClassVersion="12">
+   <version ClassVersion="12" checksum="3620501225"/>
    <version ClassVersion="11" checksum="3636199025"/>
    <version ClassVersion="10" checksum="3744464743"/>
   </class>
@@ -258,13 +262,15 @@
    <version ClassVersion="10" checksum="764455914"/>
   </class>
 
-  <class name="caf::SRNDShowerAssn" ClassVersion="12">
+  <class name="caf::SRNDShowerAssn" ClassVersion="13">
+   <version ClassVersion="13" checksum="784192775"/>
    <version ClassVersion="12" checksum="3759476703"/>
    <version ClassVersion="11" checksum="2148903847"/>
    <version ClassVersion="10" checksum="3398719456"/>
   </class>
 
-  <class name="caf::SRNDTrackAssn" ClassVersion="17">
+  <class name="caf::SRNDTrackAssn" ClassVersion="18">
+   <version ClassVersion="18" checksum="976201764"/>
    <version ClassVersion="17" checksum="2425424940"/>
    <version ClassVersion="16" checksum="1266506394"/>
    <version ClassVersion="15" checksum="2460195191"/>
@@ -300,7 +306,8 @@
    <version ClassVersion="10" checksum="1674759717"/>
   </class>
 
-    <class name="caf::SRGArTrack" ClassVersion="17">
+    <class name="caf::SRGArTrack" ClassVersion="18">
+     <version ClassVersion="18" checksum="2068237894"/>
      <version ClassVersion="17" checksum="3841055326"/>
      <version ClassVersion="16" checksum="1020294526"/>
      <version ClassVersion="15" checksum="4066948530"/>
@@ -314,7 +321,8 @@
   <class name="std::vector<caf::SRGArTrack>">
   </class>
 
-  <class name="caf::SRGArECAL" ClassVersion="13">
+  <class name="caf::SRGArECAL" ClassVersion="14">
+   <version ClassVersion="14" checksum="517237317"/>
    <version ClassVersion="13" checksum="594495245"/>
    <version ClassVersion="12" checksum="3509084697"/>
    <version ClassVersion="11" checksum="2202249478"/>

--- a/duneanaobj/StandardRecord/classes_def.xml
+++ b/duneanaobj/StandardRecord/classes_def.xml
@@ -59,6 +59,9 @@
 
   <!-- - - - - - - - - Common reco - - - - - - - - - - - - - - - - -->
 
+  <class name="caf::SRRecoObjBase" ClassVersion="10" />
+  <class name="caf::SRRecoBaseID" ClassVersion="10" />
+
   <class name="caf::SRCommonRecoBranch" ClassVersion="12">
    <version ClassVersion="12" checksum="2257468413"/>
    <version ClassVersion="11" checksum="2300096704"/>
@@ -126,7 +129,9 @@
   <class name="std::vector<caf::SRRecoParticle>">
   </class>
 
-  <enum name="PartEMethod" ClassVersion="10" />
+  <enum name="caf::PartEMethod" ClassVersion="10" />
+
+  <class name="caf::SRRecoParticleID" ClassVersion="10" />
 
   <!-- - - - - - - - Types used in det-specific situations - - - - -->
 
@@ -148,6 +153,8 @@
   <class name="std::vector<caf::SRTrack>">
   </class>
 
+  <class name="caf::SRTracker" ClassVersion="10" />
+
   <class name="caf::SRShower" ClassVersion="17">
    <version ClassVersion="17" checksum="3141158752"/>
    <version ClassVersion="16" checksum="2739725490"/>
@@ -162,9 +169,11 @@
   <class name="std::vector<caf::SRShower>">
   </class>
 
-<class name="caf::SRECALCluster" ClassVersion="17">
- <version ClassVersion="17" checksum="2003075550"/>
- <version ClassVersion="16" checksum="3312245962"/>
+  <class name="caf::SREcal" ClassVersion="10" />
+
+  <class name="caf::SRECALCluster" ClassVersion="17">
+   <version ClassVersion="17" checksum="2003075550"/>
+   <version ClassVersion="16" checksum="3312245962"/>
    <version ClassVersion="15" checksum="1197469375"/>
    <version ClassVersion="14" checksum="772507687"/>
    <version ClassVersion="13" checksum="749498947"/>
@@ -176,6 +185,7 @@
   <class name="std::vector<caf::SRECALCluster>">
   </class>
 
+  <class name="caf::SRGRAIN" ClassVersion="10" />
 
   <!-- - - - - - - - - - FD specific - - - - - - - - - - - - - - - -->
 
@@ -351,7 +361,7 @@
   <class name="caf::SRMINERvAID"  ClassVersion="10">
    <version ClassVersion="10" checksum="4040824592"/>
   </class>
-  
+
   <!-- - - - - - - - - - Truth - - - - - - - - - - - - - - - -->
 
   <class name="caf::SRTruthBranch" ClassVersion="10">


### PR DESCRIPTION
- caf::SRRecoObjBase
- caf::SRRecoBaseID
- caf::SRRecoParticleID
- caf::SRTracker
- caf::SREcal
- caf::SRGRAIN

add caf qualifying namespace to `caf::PartEMethod`