### PR TITLE
Play nice with FetchContent

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ If you want to know exactly what's in a `StandardRecord`, have a look at the [Do
 
 CAFs are intended to simplify the life of the analyzer doing physics analysis.
 
-* **CAFs are designed for fast iteration**.  
-What you want in an analysis is supposed to be here, but not everything is:   
+* **CAFs are designed for fast iteration**.
+What you want in an analysis is supposed to be here, but not everything is:
 Higher-level reconstructed objects (like tracks or showers)
   and summary truth information live here.  Charge, hit, or low-level timing information don't.
-* **CAFs are designed for easy use**.  
+* **CAFs are designed for easy use**.
   The only requirements for reading them are ROOT and the `StandardRecord` object description.
 * **CAFs are designed for one-stop shopping**.
-  A CAF bundles together information from many upstream sources and cross-links them: truth from GENIE \& GEANT, reconstruction from multiple toolkits, etc.  
+  A CAF bundles together information from many upstream sources and cross-links them: truth from GENIE \& GEANT, reconstruction from multiple toolkits, etc.
 
 
 
-## Setting up `duneanaobj` for use 
+## Setting up `duneanaobj` for use
 
 In order to work with CAFs, you'll need to have the libraries from this package accessible to the software you want to read the CAFs with.
 Depending on how you intend to read them, you may also need the development headers.
@@ -46,6 +46,37 @@ You'll then need to pass the relevant directories to your compiler and linker.
 For example, for the `gcc` suite, this means `-I/path/to/StandardRecord/dir`
 for the headers when compiling, and `-L/path/to/StandardRecord/libs -lStandardRecord`
 for the libraries when linking.
+
+### Getting CMake to build it for you
+
+The below CMake snippet will attempt to find a binary distribution of duneanaobj
+via standard CMake search methods (e.g. `ENV{duneanaobj_ROOT}`` pointing to an
+existing install prefix). If that cannot be found, then it will pull down and
+including the referenced branch and include it in your packages build:
+
+```cmake
+if(NOT DEFINED DUNE_ANAOBJ_BRANCH OR "${DUNE_ANAOBJ_BRANCH}x" STREQUAL "x")
+  set(DUNE_ANAOBJ_BRANCH v04_00_00)
+endif()
+
+find_package(duneanaobj QUIET)
+if(NOT TARGET duneanaobj::StandardRecord) # need to fetch it
+  include(FetchContent)
+  FetchContent_Declare(
+      duneanaobj
+      GIT_REPOSITORY https://github.com/DUNE/duneanaobj.git
+      GIT_TAG        ${DUNE_ANAOBJ_BRANCH}
+    )
+  set(SKIP_CET ON)
+  FetchContent_MakeAvailable(duneanaobj)
+endif()
+
+# ...
+
+add_executable(myexe myexe.cxx)
+target_link_libraries(myexe PUBLIC
+  duneanaobj::StandardRecord all::my Other::Dependencies )
+```
 
 ### Using Fermilab UPS
 
@@ -176,7 +207,7 @@ The simplest way to satisfy this dependency is again using Fermilab UPS.
 Be sure to set UPS up (see above if unsure how to do that).
 
 * You'll need to change the version that the `_CMAKE_PROJECT_VERSION_STRING` value points to
-  in the `CMakeLists.txt` file in the root of the source code directory. 
+  in the `CMakeLists.txt` file in the root of the source code directory.
   For testing, I often use `testing` as the version name, but you can pick anything that doesn't overlap with an already-existing version.
   It generally pays to make it obvious because you'll be trying to find it in a list in a minute.
 
@@ -194,7 +225,7 @@ cd $BUILD_AREA
 . $DUNEANAOBJ_SOURCE/ups/setup_for_development -d
 ```
 
-Choose `-p` for an optimized build and `-d` for a debug build. 
+Choose `-p` for an optimized build and `-d` for a debug build.
 Be sure the check the output for errors.
 
 * Assuming no errors, you can follow the directions from the output of `setup_for_development`

--- a/duneanaobj/StandardRecord/CMakeLists.txt
+++ b/duneanaobj/StandardRecord/CMakeLists.txt
@@ -73,28 +73,6 @@ else()
 
     include(GNUInstallDirs)
 
-    # Create and configure library target
-    add_library( StandardRecord SHARED
-                 ${src_files}
-               )
-
-    target_link_libraries( StandardRecord
-                           ROOT::Core ROOT::Physics
-                         )
-    target_include_directories(StandardRecord INTERFACE
-            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-            $<INSTALL_INTERFACE:include>
-            ${ROOT_INCLUDE_DIRS}
-    )
-    # Setup installation. Install the headers under include/duneanaobj/StandardRecord/
-    # so the "duneanaobj/StandardRecord/..." include paths used throughout the
-    # sources resolve against the exported include/ interface. (PUBLIC_HEADER would
-    # flatten them straight into include/, which does not match those paths.)
-    file( GLOB headers_files *.h )
-
-    install( TARGETS StandardRecord EXPORT duneanaobjTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    install( FILES ${headers_files} DESTINATION include/duneanaobj/StandardRecord )
-
     # ROOT I/O dictionary. The CET path gets this from cet's build_dictionary;
     # here we drive rootcling directly via ROOT's root_generate_dictionary,
     # fed the same classes.h / classes_def.xml selection file. The result is a
@@ -109,18 +87,32 @@ else()
 
     add_library( StandardRecord_dict SHARED G__StandardRecord.cxx )
     target_link_libraries( StandardRecord_dict
-                           PUBLIC StandardRecord ROOT::Core ROOT::Physics ROOT::TreePlayer
+                           PUBLIC ROOT::Physics ROOT::TreePlayer ROOT::Core
                          )
     target_include_directories( StandardRecord_dict INTERFACE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
             $<INSTALL_INTERFACE:include>
     )
 
-    install( TARGETS StandardRecord_dict
-             EXPORT duneanaobjTargets
-             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-           )
+    # Create and configure library target
+    add_library( StandardRecord SHARED
+                 ${src_files}
+               )
 
+    target_link_libraries( StandardRecord
+                           PUBLIC StandardRecord_dict
+                         )
+    target_include_directories(StandardRecord INTERFACE
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+            $<INSTALL_INTERFACE:include>
+    )
+
+    # useful for dependencies using FetchContent_MakeAvailable to pull this
+    # package in at configure time and link using the same name as if it had
+    # been exported/imported
+    add_library(duneanaobj::StandardRecord ALIAS StandardRecord)
+
+    install( TARGETS StandardRecord StandardRecord_dict EXPORT duneanaobjTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
     # rootcling emits these next to the build tree; ROOT looks for them beside
     # the installed library, so install them into the same libdir.
     install( FILES
@@ -128,6 +120,13 @@ else()
              "${CMAKE_CURRENT_BINARY_DIR}/libStandardRecord_dict.rootmap"
              DESTINATION ${CMAKE_INSTALL_LIBDIR}
            )
+
+    # Setup installation. Install the headers under include/duneanaobj/StandardRecord/
+    # so the "duneanaobj/StandardRecord/..." include paths used throughout the
+    # sources resolve against the exported include/ interface. (PUBLIC_HEADER would
+    # flatten them straight into include/, which does not match those paths.)
+    file( GLOB headers_files *.h )
+    install( FILES ${headers_files} DESTINATION include/duneanaobj/StandardRecord )
 
     # Setup CMake find_package related files
     install( EXPORT duneanaobjTargets


### PR DESCRIPTION
Adds the following to the README and tweaks dunenanaobj/StandardRecord/CMakeLists.txt to make it true.

### Getting CMake to build it for you

The below CMake snippet will attempt to find a binary distribution of duneanaobj
via standard CMake search methods (e.g. `ENV{duneanaobj_ROOT}`` pointing to an
existing install prefix). If that cannot be found, then it will pull down and
including the referenced branch and include it in your packages build:

```cmake
if(NOT DEFINED DUNE_ANAOBJ_BRANCH OR "${DUNE_ANAOBJ_BRANCH}x" STREQUAL "x")
  set(DUNE_ANAOBJ_BRANCH v04_00_00)
endif()

find_package(duneanaobj QUIET)
if(NOT TARGET duneanaobj::StandardRecord) # don't need to fetch it
  include(FetchContent)
  FetchContent_Declare(
      duneanaobj
      GIT_REPOSITORY https://github.com/DUNE/duneanaobj.git
      GIT_TAG        ${DUNE_ANAOBJ_BRANCH}
    )
  set(SKIP_CET ON)
  FetchContent_MakeAvailable(duneanaobj)
endif()

# ...

add_executable(myexe myexe.cxx)
target_link_libraries(myexe PUBLIC
  duneanaobj::StandardRecord all::my Other::Dependencies )
```